### PR TITLE
Added check for HDF5 datasets with type = object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Make References",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": [
+                "-if",
+                "TEST00USA_R_20203370000_01D_15S_MO.rnx.nc"
+            ],
+            "cwd": "/Users/metadatagamechanger/data/UNAVCO/rinexData/p226/testData"            
+        }
+    ]
+}

--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -15,7 +15,6 @@ import fsspec.core
 
 lggr = logging.getLogger('h5-to-zarr')
 
-
 class SingleHdf5ToZarr:
     """Translate the content of one HDF5 file into Zarr metadata.
 
@@ -147,13 +146,21 @@ class SingleHdf5ToZarr:
         """
         refs = {}
         if isinstance(h5obj, h5py.Dataset):
-            lggr.debug(f'HDF5 dataset: {h5obj.name}')
+            lggr.debug(f'HDF5 dataset: {h5obj.name} dataType: {h5obj.dtype}')
             if h5obj.id.get_create_plist().get_layout() == h5py.h5d.COMPACT:
                 RuntimeError(
                     f'Compact HDF5 datasets not yet supported: <{h5obj.name} '
                     f'{h5obj.shape} {h5obj.dtype} {h5obj.nbytes} bytes>')
                 return
-
+            #
+            # check for unsupported HDF DataTypes
+            #
+            if h5obj.dtype == 'object':
+                lggr.warning(f'HDF5 variable length strings are not yet supported: <{h5obj.name} ')
+                lggr.warning(f'shape: {h5obj.shape} type: {h5obj.dtype} bytes: {h5obj.nbytes} bytes>')
+                RuntimeError(
+                    f'{h5obj.shape} {h5obj.dtype} {h5obj.nbytes} bytes>')
+                return
             #
             # check for unsupported HDF encoding/filters
             #


### PR DESCRIPTION
This avoids crashes when files with variable-length strings are read. Warnings are posted...

I know there are other HDF5 types that are not supported at present... probably compound datasets... Will add that when I get sample.