### PR TITLE
Using JSON file instead of intake

### DIFF
--- a/examples/earthbigdata.ipynb
+++ b/examples/earthbigdata.ipynb
@@ -42,17 +42,18 @@
    "id": "a13456f4-35ce-4254-a172-ca26b320661d",
    "metadata": {},
    "outputs": [],
-   "source": [zarr_all_url='https://sentinel-1-global-coherence-earthbigdata.s3.us-west-2.amazonaws.com/data/wrappers/zarr-all.json'
-
-mapper = fsspec.get_mapper(
-    'reference://',
-    fo=zarr_all_url,
-    target_protocol='http',
-)
-dataset = xr.open_dataset(
-    mapper, engine='zarr', backend_kwargs={'consolidated': False}
-)
-dataset]
+   "source": [
+    "zarr_all_url='https://sentinel-1-global-coherence-earthbigdata.s3.us-west-2.amazonaws.com/data/wrappers/zarr-all.json'"
+    "mapper = fsspec.get_mapper("
+    "'reference://',"
+    "fo=zarr_all_url,"
+    "target_protocol='http',"
+    ")"
+    "dataset = xr.open_dataset("
+    "mapper, engine='zarr', backend_kwargs={'consolidated': False}"
+    ")"
+    "dataset"
+   ]
   },
   {
    "cell_type": "code",

--- a/examples/earthbigdata.ipynb
+++ b/examples/earthbigdata.ipynb
@@ -42,11 +42,17 @@
    "id": "a13456f4-35ce-4254-a172-ca26b320661d",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%%time\n",
-    "dataset = intake.open_data(\"https://github.com/fsspec/kerchunk/raw/main/\"\n",
-    "                           \"examples/intake_catalog.yml\")['sentinel_seasonal'].read()"
-   ]
+   "source": [zarr_all_url='https://sentinel-1-global-coherence-earthbigdata.s3.us-west-2.amazonaws.com/data/wrappers/zarr-all.json'
+
+mapper = fsspec.get_mapper(
+    'reference://',
+    fo=zarr_all_url,
+    target_protocol='http',
+)
+dataset = xr.open_dataset(
+    mapper, engine='zarr', backend_kwargs={'consolidated': False}
+)
+dataset]
   },
   {
    "cell_type": "code",

--- a/examples/earthbigdata.ipynb
+++ b/examples/earthbigdata.ipynb
@@ -43,16 +43,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zarr_all_url='https://sentinel-1-global-coherence-earthbigdata.s3.us-west-2.amazonaws.com/data/wrappers/zarr-all.json'"
-    "mapper = fsspec.get_mapper("
-    "'reference://',"
-    "fo=zarr_all_url,"
-    "target_protocol='http',"
-    ")"
-    "dataset = xr.open_dataset("
-    "mapper, engine='zarr', backend_kwargs={'consolidated': False}"
-    ")"
-    "dataset"
    ]
   },
   {

--- a/examples/earthbigdata.ipynb
+++ b/examples/earthbigdata.ipynb
@@ -43,15 +43,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "48c9595d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "zarr_all_url='https://sentinel-1-global-coherence-earthbigdata.s3.us-west-2.amazonaws.com/data/wrappers/zarr-all.json'\n",
+    "\n",
+    "mapper = fsspec.get_mapper(\n",
+    "    'reference://',\n",
+    "    fo=zarr_all_url,\n",
+    "    target_protocol='http',\n",
+    ")\n",
+    "dataset = xr.open_dataset(\n",
+    "    mapper, engine='zarr', backend_kwargs={'consolidated': False}\n",
+    ")\n",
     "dataset"
    ]
   },
@@ -310,9 +311,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:seppoloc]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-seppoloc-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -324,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changing the cell calling intake with a direct call to mapping via the JSON file describing the zarr format which resides on the AWS registry of open data repository where the data set resides as well. Users will need to change to their working kernel.