### PR TITLE
document the option of manually loading and writing the json metadata

### DIFF
--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -65,6 +65,12 @@ class MultiZarrToZarr:
 
         storage_options : dict
             When using an fsspec URL to write to remote
+
+        Returns
+        -------
+        dict or None
+            If outpath was given, the metadata is encoded as json and
+            written to that file. If not, it is returned directly.
         """
         self._open_mappers()
         ds, ds0, fss = self._determine_dims()

--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -18,9 +18,11 @@ class MultiZarrToZarr:
 
     Parameters
     ----------
-    path: string or list of strings
-        List of JSON paths or a URL containing multiple JSONs
-    
+    path: string, list of strings or list of dict
+        List of JSON paths or a URL containing multiple JSONs. If a
+        list of mappings, this is the json-decoded content of the
+        files.
+
     remote_protocol: string
         Protocol used to access remote files (e.g. 's3', 'az', etc)
 

--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -21,7 +21,7 @@ class MultiZarrToZarr:
     path: string, list of strings or list of dict
         List of JSON paths or a URL containing multiple JSONs. If a
         list of dicts, this is the json-decoded content of the
-        files (such as the output of many calls to``kerchunk.hdf.SingleHdf5ToZarr()``.
+        files (such as the output of many calls to``kerchunk.hdf.SingleHdf5ToZarr()``).
 
     remote_protocol: string
         Protocol used to access remote files (e.g. 's3', 'az', etc)

--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -20,8 +20,8 @@ class MultiZarrToZarr:
     ----------
     path: string, list of strings or list of dict
         List of JSON paths or a URL containing multiple JSONs. If a
-        list of mappings, this is the json-decoded content of the
-        files.
+        list of dicts, this is the json-decoded content of the
+        files (such as the output of many calls to``kerchunk.hdf.SingleHdf5ToZarr()``.
 
     remote_protocol: string
         Protocol used to access remote files (e.g. 's3', 'az', etc)


### PR DESCRIPTION
`MultiZarrToZarr` uses `fsspec.open_files` to open all files at once. Even though this makes sense for remote filesystems, it fails with a lot of small files on a local filesystem: opening a lot of files at once will exceed the limit for open file descriptors. It is still possible to use `MultiZarrToZarr` in this case because `path` can be passed the pre-loaded metadata. This, however, is currently undocumented.

Writing to a file object is also not possible (I was trying to use `fsspec`'s compression support), but `translate` will return the metadata if it doesn't receive a value for `outpath`. While this is documented, I didn't immediately understand how to use that so I hope this might make it a bit clearer.
