### PR TITLE
Fix netcdf datetime handling

### DIFF
--- a/kerchunk/hdf.py
+++ b/kerchunk/hdf.py
@@ -173,6 +173,8 @@ class SingleHdf5ToZarr:
                 compression = None
             if h5obj.dtype.kind in "UVS":
                 fill = h5obj.fillvalue or " "
+            elif _is_netcdf_datetime(h5obj):
+                fill = None
             else:
                 fill = h5obj.fillvalue
             
@@ -302,3 +304,12 @@ class SingleHdf5ToZarr:
                     [a // b for a, b in zip(blob.chunk_offset, chunk_size)])
                 stinfo[key] = {'offset': blob.byte_offset, 'size': blob.size}
             return stinfo
+
+
+def _is_netcdf_datetime(dataset: h5py.Dataset):
+    units = dataset.attrs.get("units")
+    if isinstance(units, bytes):
+        units = units.decode("utf-8")
+    # This is the same heuristic used by xarray
+    # https://github.com/pydata/xarray/blob/f8bae5974ee2c3f67346298da12621af4cae8cf8/xarray/coding/times.py#L670
+    return units and "since" in units

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+cftime
+dask
+h5netcdf
+h5py
+jinja2
+mypy
+pytest
+s3fs
+types-ujson
+xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 fsspec
+numcodecs
+numpy
 ujson
+zarr

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,12 @@ setup(
     long_description=(open('README.md').read() if exists('README.md') else ''),
     long_description_content_type='text/markdown',
     install_requires=list(open('requirements.txt').read().strip().split('\n')),
+    extras_require={
+        "cftime": ["cftime"],
+        "fits": ["xarray"],
+        "hdf": ["h5py", "xarray"],
+        "grib2": ["cfgrib"],
+    },
     entry_points={
         'numcodecs.codecs': [
             'grib = kerchunk.grib2:GRIBCodec',


### PR DESCRIPTION
Fixes netcdf datetime handling by removing the fill value if the dataset is a netcdf datetime. NetCDF datetimes are detected using the same heuristic that xarray uses: https://github.com/pydata/xarray/blob/f8bae5974ee2c3f67346298da12621af4cae8cf8/xarray/coding/times.py#L670.

## Related issues
- Closes #115 

## Additional changes
- Adds more required dependencies to `requirements.txt`
- Adds a `requirements-dev.txt` with development dependencies, for developers that aren't using conda