### PR TITLE
Update hdf.py

### DIFF
--- a/kerchunk/hdf.py
+++ b/kerchunk/hdf.py
@@ -177,6 +177,7 @@ class SingleHdf5ToZarr:
             elif h5obj.dtype.kind == "O":
                 kwargs["data"] = h5obj[:]
                 kwargs["object_codec"] = numcodecs.MsgPack()
+                fill = None
             elif _is_netcdf_datetime(h5obj):
                 fill = None
             else:


### PR DESCRIPTION
possible fill = None fix for now ??

Noticed this when using switching to using latest kerchunk in a container on AWS.