### PR TITLE
Fix doc testing

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx-rtd-theme
-numpydoc
+numpydoc==1.2.1
 autodoc
 numpy
 fsspec


### PR DESCRIPTION
Error was w/ latest numpydoc requiring sphinx 3.0, which is not included in the build action image