### PR TITLE
Speed up combine

### DIFF
--- a/kerchunk/fits.py
+++ b/kerchunk/fits.py
@@ -137,6 +137,7 @@ class AsciiTableCodec(numcodecs.abc.Codec):
         pass
 
 
+numcodecs.register_codec(AsciiTableCodec, "FITSAscii")
 ncv = [int(i) for i in numcodecs.__version__.split(".")[:3]]
 if ncv < [0, 10]:
     numcodecs.register_codec(AsciiTableCodec, "FITSAscii")

--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -4,8 +4,12 @@ from operator import mul
 from numcodecs.abc import Codec
 import numpy as np
 try:
+    # causes warning on newer scipy, all moved to scipy.io
+    # TODO: this construct is only here to make the codec importable without
+    #  scipy. Should instead move to separate module.
     from scipy.io.netcdf import ZERO, NC_VARIABLE, netcdf_file, netcdf_variable
 except ImportError:
+
     netcdf_file = object
 
 import fsspec

--- a/kerchunk/tests/test_combine.py
+++ b/kerchunk/tests/test_combine.py
@@ -232,7 +232,7 @@ def test_get_coos(refs, selector, expected):
     mzz = MultiZarrToZarr([refs["single1"], refs["single2"]], remote_protocol="memory",
                           concat_dims=["time"], coo_map={"time": selector})
     mzz.first_pass()
-    assert mzz.coos["time"] == expected
+    assert mzz.coos["time"].tolist() == expected
     mzz.store_coords()
     g = zarr.open(mzz.out)
     assert g['time'][:].tolist() == expected
@@ -243,14 +243,14 @@ def test_coo_vars(refs):
     mzz = MultiZarrToZarr([refs["simple1"], refs["simple_var1"]], remote_protocol="memory",
                           concat_dims=["var"])
     mzz.first_pass()
-    assert mzz.coos["var"] == ["data", "datum"]
+    assert mzz.coos["var"].tolist() == ["data", "datum"]
 
     mzz = MultiZarrToZarr([refs["simple1"], refs["simple2"], refs["simple_var1"], refs["simple_var2"]],
                           remote_protocol="memory",
                           concat_dims=["var", "time"], coo_map={"time": "attr:attr0"})
     mzz.first_pass()
-    assert mzz.coos["var"] == ["data", "datum"]
-    assert mzz.coos["time"] == [3, 4]
+    assert mzz.coos["var"].tolist() == ["data", "datum"]
+    assert mzz.coos["time"].tolist() == [3, 4]
 
 
 def test_single(refs):

--- a/kerchunk/tests/test_combine.py
+++ b/kerchunk/tests/test_combine.py
@@ -362,6 +362,24 @@ def test_var(refs):
     assert (z.datum.values == arr).all()
 
 
+def test_var_dimension(refs):
+    mzz = MultiZarrToZarr([refs["simple1"], refs["simple_var1"]], remote_protocol="memory",
+                          coo_map={"varname": "VARNAME", "var": "output"})
+    out = mzz.translate()
+    z = xr.open_dataset(
+        "reference://",
+        backend_kwargs={"storage_options": {"fo": out, "remote_protocol": "memory"},
+                        "consolidated": False},
+        engine="zarr",
+        chunks={}
+    )
+    assert list(z) == ["output"]
+    assert list(z.dims) == ["varname", "x", "y"]
+    assert list(z.varname) == ["data", "datum"]
+    assert z.output.shape == (2, 10, 10)
+    assert (z.output.values == arr).all()
+
+
 def test_var_and_dim(refs):
     mzz = MultiZarrToZarr([refs["simple1"], refs["simple2"], refs["simple_var1"], refs["simple_var2"]],
                           remote_protocol="memory", concat_dims=["var", "dim"],

--- a/kerchunk/tests/test_netcdf.py
+++ b/kerchunk/tests/test_netcdf.py
@@ -12,8 +12,10 @@ data = xr.DataArray(
     dims=["x", "y"],
     name="data",
 )
-bdata = xr.Dataset({"data": data}, attrs={"attr0": 3}
-                  ).to_netcdf(format="NETCDF3_CLASSIC")
+bdata = xr.Dataset(
+    {"data": data}, attrs={"attr0": 3}
+).to_netcdf(format="NETCDF3_CLASSIC")
+
 m = fsspec.filesystem("memory")
 m.pipe("data.nc3", bdata)
 


### PR DESCRIPTION
- get file sizes directly, where possible
- use np arrays and searchsorted instead of list index

@peterm790 , I get a combine time for the two intermediate JSON files of about 3s with this and https://github.com/fsspec/filesystem_spec/pull/985