### PR TITLE
Complete first version of netCDF3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        exclude: ^docs/
+  - repo: https://github.com/pycqa/flake8
+    rev: '4.0.1'
+    hooks:
+      - id: flake8
+        exclude: tests/|^docs/|__init__.py

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -23,5 +23,6 @@ dependencies:
   - black
   - pip
   - tifffile
+  - netCDF4
   - pip:
       - git+https://github.com/fsspec/filesystem_spec

--- a/ci/environment-py39.yml
+++ b/ci/environment-py39.yml
@@ -23,5 +23,6 @@ dependencies:
   - black
   - pip
   - tifffile
+  - netCDF4
   - pip:
       - git+https://github.com/fsspec/filesystem_spec

--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -40,12 +40,12 @@ class NetCDF3ToZarr(netcdf_file):
         storage_options: dict
             passed to fsspec when opening filename
         inline_threshold: int
-            Byte size below which an array will be embedded in the output
+            Byte size below which an array will be embedded in the output [TBC]
         max_chunk_size: int
             How big a chunk can be before triggering subchunking. If 0, there is no
             subchunking, and there is never subchunking for coordinate/dimension arrays.
             E.g., if an array contains 10,000bytes, and this value is 6000, there will
-            be two output chunks, split on the biggest available dimension.
+            be two output chunks, split on the biggest available dimension. [TBC]
         args, kwargs: passed to scipy superclass ``scipy.io.netcdf.netcdf_file``
         """
         if netcdf_file is object:
@@ -53,14 +53,18 @@ class NetCDF3ToZarr(netcdf_file):
         assert kwargs.pop("mmap", False) is False
         assert kwargs.pop("mode", "r") == "r"
         assert kwargs.pop("maskandscale", False) is False
+
+        # attributes set before super().__init__ don' accidentally turn into
+        # dataset attribues
         self.chunks = {}
         self.threshold = inline_threshold
-        self.max_chukn_size = max_chunk_size
+        self.max_chunk_size = max_chunk_size
+        self.out = {}
         with fsspec.open(filename, **(storage_options or {})) as fp:
             super().__init__(
                 fp, *args, mmap=False, mode="r", maskandscale=False, **kwargs
             )
-        self.filename = filename
+        self.filename = filename  # this becomes an attribute, so must ignore on write
 
     def _read_var_array(self):
         header = self.fp.read(4)
@@ -149,7 +153,6 @@ class NetCDF3ToZarr(netcdf_file):
         """
         import zarr
 
-        self.out = {}
         out = self.out
         z = zarr.open(out, mode="w")
         for dim, var in self.variables.items():
@@ -245,6 +248,7 @@ class NetCDF3ToZarr(netcdf_file):
             {
                 k: v.decode() if isinstance(v, bytes) else str(v)
                 for k, v in self._attributes.items()
+                if k != "filename"  # special "attribute"
             }
         )
 

--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -239,8 +239,8 @@ class NetCDF3ToZarr(netcdf_file):
                 for i in range(outer_shape):
                     out[f"{name}/{i}{suffix}"] = [
                         self.filename,
-                        offset + i * dt.itemsize,
-                        dtype.itemsize,
+                        int(offset + i * dt.itemsize),
+                        int(dtype.itemsize),
                     ]
 
                 offset += dtype.itemsize
@@ -252,9 +252,12 @@ class NetCDF3ToZarr(netcdf_file):
             }
         )
 
-        # TODO: embed coordinates, especially the record array one
+        # remove bytes
+        out = {
+            k: (v.decode() if isinstance(v, bytes) else v) for k, v in self.out.items()
+        }
 
-        return {"version": 1, "refs": self.out}
+        return {"version": 1, "refs": out}
 
 
 netcdf_recording_file = NetCDF3ToZarr

--- a/kerchunk/tests/test_netcdf.py
+++ b/kerchunk/tests/test_netcdf.py
@@ -62,11 +62,8 @@ def unlimited_dataset(tmpdir):
     temp.units = "K"
     latitudes[:] = np.arange(-0.5, 0.5, 0.1)
     longitudes[:] = np.arange(0, 0.5, 0.1)
-    from numpy.random import uniform
-
-    temp[0] = uniform(size=(1, 10, 5))
-    for i in range(1, 8):
-        temp[i] = uniform(size=(1, 10, 5))
+    for i in range(8):
+        temp[i] = np.random.uniform(size=(1, 10, 5))
     rootgrp.close()
     return fn
 

--- a/kerchunk/tests/test_netcdf.py
+++ b/kerchunk/tests/test_netcdf.py
@@ -1,5 +1,6 @@
+import os
+
 import fsspec
-import io
 import numpy as np
 import pytest
 from kerchunk import netCDF3
@@ -33,3 +34,58 @@ def test_one():
         },
     )
     assert (ds.data == data).all()
+
+
+@pytest.fixture()
+def unlimited_dataset(tmpdir):
+    # https://unidata.github.io/netcdf4-python/#creatingopeningclosing-a-netcdf-file
+    from netCDF4 import Dataset
+
+    fn = os.path.join(tmpdir, "test.nc")
+    rootgrp = Dataset(fn, "w", format="NETCDF3_CLASSIC")
+    rootgrp.createDimension("time", None)
+    rootgrp.createDimension("lat", 10)
+    rootgrp.createDimension("lon", 5)
+    rootgrp.createVariable("time", "f8", ("time",))
+    rootgrp.title = "testing"
+    latitudes = rootgrp.createVariable("lat", "f4", ("lat",))
+    longitudes = rootgrp.createVariable("lon", "f4", ("lon",))
+    temp = rootgrp.createVariable(
+        "temp",
+        "f4",
+        (
+            "time",
+            "lat",
+            "lon",
+        ),
+    )
+    temp.units = "K"
+    latitudes[:] = np.arange(-0.5, 0.5, 0.1)
+    longitudes[:] = np.arange(0, 0.5, 0.1)
+    from numpy.random import uniform
+
+    temp[0] = uniform(size=(1, 10, 5))
+    for i in range(1, 8):
+        temp[i] = uniform(size=(1, 10, 5))
+    rootgrp.close()
+    return fn
+
+
+def test_unlimited(unlimited_dataset):
+    fn = unlimited_dataset
+    expected = xr.open_dataset(fn, engine="scipy")
+    h = netCDF3.NetCDF3ToZarr(fn)
+    out = h.translate()
+    ds = xr.open_dataset(
+        "reference://",
+        engine="zarr",
+        backend_kwargs={
+            "consolidated": False,
+            "storage_options": {"fo": out},
+        },
+    )
+    assert ds.attrs["title"] == "testing"
+    assert ds.temp.attrs["units"] == "K"
+    assert (ds.lat.values == expected.lat.values).all()
+    assert (ds.lon.values == expected.lon.values).all()
+    assert (ds.temp.values == expected.temp.values).all()


### PR DESCRIPTION
Fixes #187 

Provides no chunking on normal arrays, and "native" chunking on append axis variables, i.e., one chunk per sample. Does not yet embed the coordinate along that dimension. This means that, for the typical case of a time-series, the time coordinate will be eagerly-loaded by xarray by fetching a whole bunch of 4- or 8-byte values from the file at open time. maskandscale ("add_offset", "scale_factor") is not tested, since I don't have a test file for that.

This kind of consolidation, as well as converting bytes to str for saving to file, ought to be done in a single location, probably in kerchunk.utils.

@rabernat , for 'https://g-f83d26.7a577b.6fbd.data.globus.org/nw2_0.25deg_N15_baseline_hmix5/snapshots_30005.nc', xarray only opens the output with `decode_times=False`, which is true for the original nc too.

```
Dimensions:  (time: 100, zl: 15, yh: 560, xh: 240, zi: 16, xq: 241, yq: 561)
Coordinates:
  * time     (time) float64 3.000e+04 3.001e+04 3.002e+04 ... 3.05e+04 3.05e+04
  * xh       (xh) float64 0.125 0.375 0.625 0.875 ... 59.12 59.38 59.62 59.88
  * xq       (xq) float64 0.0 0.25 0.5 0.75 1.0 ... 59.0 59.25 59.5 59.75 60.0
  * yh       (yh) float64 -69.88 -69.62 -69.38 -69.12 ... 69.38 69.62 69.88
  * yq       (yq) float64 -70.0 -69.75 -69.5 -69.25 ... 69.25 69.5 69.75 70.0
  * zi       (zi) float64 1.022e+03 1.023e+03 1.023e+03 ... 1.028e+03 1.028e+03
  * zl       (zl) float64 1.023e+03 1.023e+03 1.023e+03 ... 1.028e+03 1.028e+03
Data variables:
    KE       (time, zl, yh, xh) float32 ...
    e        (time, zi, yh, xh) float64 ...
    h        (time, zl, yh, xh) float32 ...
    u        (time, zl, yh, xq) float32 ...
    uh       (time, zl, yh, xq) float32 ...
    v        (time, zl, yq, xh) float32 ...
    vh       (time, zl, yq, xh) float32 ...
Attributes:
    associated_files:  area_t: static.nc
    grid_tile:         N/A
    grid_type:         regular
    title:             NeverWorld2
```