### PR TITLE
Fix temp files in _split_file

### DIFF
--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -33,10 +33,10 @@ def _split_file(f, skip=0):
         data = f.read(part_size)
         assert data[:4] == b"GRIB"
         assert data[-4:] == b"7777"
-        fn = tempfile.mktemp(suffix="grib2")
-        with open(fn, "wb") as fo:
+        with tempfile.NamedTemporaryFile(suffix="grib2") as fo:
             fo.write(data)
-        yield fn, start, part_size
+            fo.flush()
+        yield fo.name, start, part_size
         part += 1
         if skip and part > skip:
             break


### PR DESCRIPTION
Similar to #199 temp files must be removed in _split_file for scan_grib.
Using the context manager is the easiest way...
Not entirely sure why the flush is necessary, but it appears to be in local testing on my mac.

See also #194 