### PR TITLE
add group support in MultiZarrToZarr

### DIFF
--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -346,7 +346,8 @@ class MultiZarrToZarr:
                 if ".zgroup" in attrs:
                     if v:
                         # non-base groups need group metadata copied
-                        self.out[f"{v}/.zgroup"] = m[f"{v}/.zgroup"]
+                        for fn in [".zgroup", ".zattrs"]:
+                            self.out[f"{v}/{fn}"] = m[f"{v}/{fn}"]
                     continue
                 if v in self.identical_dims:
                     if f"{v}/.zarray" in self.out:

--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -339,9 +339,14 @@ class MultiZarrToZarr:
                     cv = tuple(sorted(set(cv)))[0]
                     cvalues[c] = cv
 
-            for v in fs.ls("", detail=False):
+            for v, _, attrs in fs.walk("", detail=False):
                 if v in self.coo_map or v in skip or v.startswith(".z"):
                     # already made coordinate variables and metadata
+                    continue
+                if ".zgroup" in attrs:
+                    if v:
+                        # non-base groups need group metadata copied
+                        self.out[f"{v}/.zgroup"] = m[f"{v}/.zgroup"]
                     continue
                 if v in self.identical_dims:
                     if f"{v}/.zarray" in self.out:
@@ -405,7 +410,7 @@ class MultiZarrToZarr:
                     # loop over the chunks and copy the references
                     if ".z" in fn:
                         continue
-                    key_parts = fn.split("/", 1)[1].split(".")
+                    key_parts = fn.split("/")[-1].split(".")
                     key = f"{var or v}/"
                     for loc, c in enumerate(coord_order):
                         if c in self.coos:

--- a/kerchunk/tests/test_combine.py
+++ b/kerchunk/tests/test_combine.py
@@ -72,6 +72,8 @@ data = xr.DataArray(
     attrs={"attr0": 0},
 )
 xr.Dataset({"data": data}).to_zarr("memory://quad_nochunk1.zarr")
+xr.Dataset(coords={"time": np.array([1, 2, 3, 4])}).to_zarr("memory://group1.zarr")
+xr.Dataset({"data": data}).to_zarr("memory://group1.zarr", group="group", mode="a")
 
 data = xr.DataArray(
     data=np.vstack([arr] * 4),
@@ -81,6 +83,8 @@ data = xr.DataArray(
     attrs={"attr0": 0},
 )
 xr.Dataset({"data": data}).to_zarr("memory://quad_nochunk2.zarr")
+xr.Dataset(coords={"time": np.array([5, 6, 7, 8])}).to_zarr("memory://group2.zarr")
+xr.Dataset({"data": data}).to_zarr("memory://group2.zarr", group="group", mode="a")
 
 data = xr.DataArray(
     data=da.from_array(np.vstack([arr] * 4), chunks=(1, 10, 10)),
@@ -366,6 +370,7 @@ def test_outfile_postprocess(refs):
         [["quad_nochunk1", "quad_nochunk2"], ((4, 4), (10,), (10,))],
         [["quad_1chunk1", "quad_1chunk2"], ((1,) * 8, (10,), (10,))],
         [["quad_2chunk1", "quad_2chunk2"], ((2,) * 4, (10,), (10,))],
+        [["group1", "group2"], ((4, 4), (10,), (10,))],
     ],
 )
 def test_chunked(refs, inputs, chunks):
@@ -383,6 +388,7 @@ def test_chunked(refs, inputs, chunks):
         },
         engine="zarr",
         chunks={},
+        group="group" if "group" in inputs[0] else None,
     )
     # TODO: make some assert_eq style function
     assert z.time.values.tolist() == [1, 2, 3, 4, 5, 6, 7, 8]

--- a/kerchunk/tests/test_combine.py
+++ b/kerchunk/tests/test_combine.py
@@ -72,8 +72,7 @@ data = xr.DataArray(
     attrs={"attr0": 0},
 )
 xr.Dataset({"data": data}).to_zarr("memory://quad_nochunk1.zarr")
-xr.Dataset(coords={"time": np.array([1, 2, 3, 4])}).to_zarr("memory://group1.zarr")
-xr.Dataset({"data": data}).to_zarr("memory://group1.zarr", group="group", mode="a")
+xr.Dataset({"data": data}).to_zarr("memory://group1.zarr", group="group")
 
 data = xr.DataArray(
     data=np.vstack([arr] * 4),
@@ -83,8 +82,7 @@ data = xr.DataArray(
     attrs={"attr0": 0},
 )
 xr.Dataset({"data": data}).to_zarr("memory://quad_nochunk2.zarr")
-xr.Dataset(coords={"time": np.array([5, 6, 7, 8])}).to_zarr("memory://group2.zarr")
-xr.Dataset({"data": data}).to_zarr("memory://group2.zarr", group="group", mode="a")
+xr.Dataset({"data": data}).to_zarr("memory://group2.zarr", group="group")
 
 data = xr.DataArray(
     data=da.from_array(np.vstack([arr] * 4), chunks=(1, 10, 10)),
@@ -378,6 +376,7 @@ def test_chunked(refs, inputs, chunks):
         [refs[inputs[0]], refs[inputs[1]]],
         remote_protocol="memory",
         concat_dims=["time"],
+        coo_map={"time": "data:group/time"} if "group" in inputs[0] else None,
     )
     out = mzz.translate()
     z = xr.open_dataset(


### PR DESCRIPTION
This PR updates MultiZarrToZarr to support groups.  One important limitation: as it stands I think coordinates need to be available in the base group to work.  Supporting coordinates interspersed amongst different groups seems like it would need a fair amount of changes in the coordinate selector logic.  

Closes #191 