### PR TITLE
Modifies coord attrs lookup for non-coord levels on GRIB2 files

### DIFF
--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -162,6 +162,7 @@ def scan_grib(
                     attrs = cfgrib.dataset.COORD_ATTRS[name]
                 except KeyError:
                     logger.debug(f"Couldn't find coord {name} in dataset")
+                    attrs = {}
                 attrs["_ARRAY_DIMENSIONS"] = [name]
                 _store_array(
                     store, z, data, name, inline_threshold, offset, size, attrs

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -158,7 +158,10 @@ def scan_grib(
             if "typeOfLevel" in m and "level" in m:
                 name = m["typeOfLevel"]
                 data = np.array([m["level"]])
-                attrs = cfgrib.dataset.COORD_ATTRS[name]
+                try:
+                    attrs = cfgrib.dataset.COORD_ATTRS[name]
+                except KeyError:
+                    logger.warning(f"Couldn't find coord {name} in dataset")
                 attrs["_ARRAY_DIMENSIONS"] = [name]
                 _store_array(
                     store, z, data, name, inline_threshold, offset, size, attrs

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -161,7 +161,7 @@ def scan_grib(
                 try:
                     attrs = cfgrib.dataset.COORD_ATTRS[name]
                 except KeyError:
-                    logger.warning(f"Couldn't find coord {name} in dataset")
+                    logger.debug(f"Couldn't find coord {name} in dataset")
                 attrs["_ARRAY_DIMENSIONS"] = [name]
                 _store_array(
                     store, z, data, name, inline_threshold, offset, size, attrs


### PR DESCRIPTION
I ran across an interesting edge case while trying to read in some GRIB files from the NOAA HRRR model using @martindurant's awesome improvements from #198. The edge case occurs when you supply a `typeOfLevel` filter, but the level is not actually a coordinate in the dataset. The most common use case for this is selecting the **surface** fields (including certain thermodynamic fields like skin temperature, or winds). In this case, the attribute lookup into the decoded `COORD_ATTRS` on the dataset hat cfgrib produces will fail, but the `scan_grib` will keep on running through, producing empty references that need to be dealt with.

The changelist here is a very, very naive way of fixing this - simply grabbing the basic attributes that have already been inspected. I'm sure there are better ways. But this PR is primarily to exposure to the community and get feedback for a better solution.

## To Reproduce

- Grab a recent HRRR file from NOMADS (e.g. [here](https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/hrrr.20220725/conus/), subbing in the most recent YYYYMMDD for the date)
- Run the following code snippet:
  ``` python
  from kerchunk.grib2 import scan_grib
  hrrr_fn = "/path/to/hrrr/grib"
  grib_references = scan_grib(
      hrrr_fn,
      common=['time', 'latitude', 'longitude', 'valid_time']
      storage_options={}, 
      inline_threshold=0,
      filter={'typeOfLevel': 'surface', 'shortName': 't'},  # for selecting the single surface temp message 
  )
  ```