### PR TITLE
Add warning when combine coords are likely bad

### DIFF
--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -2,6 +2,7 @@ import base64
 import collections.abc
 import logging
 import re
+import warnings
 
 import fsspec
 import fsspec.utils
@@ -243,6 +244,10 @@ class MultiZarrToZarr:
                     coos[var].add(value)
 
         self.coos = _reorganise(coos)
+        for c, v in self.coos.items():
+            if len(v) < 2:
+                warnings.warn(f"Concatenated coordinate '{c}' contains less than expected"
+                              f"number of values across the datasets: {v}")
         logger.debug("Created coordinates map")
         self.done.add(1)
         return coos

--- a/kerchunk/tests/test_combine.py
+++ b/kerchunk/tests/test_combine.py
@@ -564,3 +564,16 @@ def test_merge_vars():
     fs.pipe("file2.json", b'''{"version": 1, "refs": {"item2": 2}}''')
     merge = kerchunk.combine.merge_vars(['memory://file1.json', 'memory://file2.json'])
     assert list(merge['refs']) == ['item1', 'item2']
+
+
+def test_bad_coo_warning(refs):
+    def f(*_, **__):
+        return 1
+    mzz = MultiZarrToZarr(
+        [refs["single1"], refs["single2"]],
+        remote_protocol="memory",
+        concat_dims=["time"],
+        coo_map={"time": f},
+    )
+    with pytest.warns(match="contains less than expected"):
+        mzz.first_pass()


### PR DESCRIPTION
@ashiklom , this would have at least given you a warning when combining that your times didn't get parsed.