### PR TITLE
ModuleNotFoundError/ImportError messages

### DIFF
--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -1,8 +1,14 @@
+from ast import Import
 import base64
 import logging
 
-import cfgrib
-import eccodes
+try:
+    import cfgrib
+    import eccodes
+except ModuleNotFoundError as err:
+    if err.name == 'cfgrib': raise ImportError('cfgrib is needed to kerchunk GRIB2 files. Please install it with `conda install -c conda-forge cfgrib`')    
+    if err.name == 'eccodes': raise ImportError('eccodes is needed to kercunk GRIB2 files. Please install it with `conda install -c conda-forge eccodes`')
+
 import fsspec
 import zarr
 import numpy as np

--- a/kerchunk/hdf.py
+++ b/kerchunk/hdf.py
@@ -4,11 +4,15 @@ from typing import Union, BinaryIO
 
 import fsspec.core
 import numpy as np
-import h5py
 import zarr
 from zarr.meta import encode_fill_value
 import numcodecs
 from .codecs import FillStringsCodec
+
+try:
+    import h5py
+except ModuleNotFoundError:
+    raise ImportError("h5py is required for kerchunking HDF5/NetCDF4 files. Please install with `pip/conda install h5py`")
 
 lggr = logging.getLogger("h5-to-zarr")
 _HIDDEN_ATTRS = {  # from h5netcdf.attrs
@@ -66,6 +70,7 @@ class SingleHdf5ToZarr:
         error="warn",
         vlen_encode="embed",
     ):
+        
         # Open HDF5 file in read mode...
         lggr.debug(f"HDF5 file: {h5f}")
         if isinstance(h5f, str):

--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -3,7 +3,10 @@ from operator import mul
 
 import numpy as np
 
-from scipy.io.netcdf import ZERO, NC_VARIABLE, netcdf_file, netcdf_variable
+try:
+    from scipy.io.netcdf import ZERO, NC_VARIABLE, netcdf_file, netcdf_variable
+except ModuleNotFoundError:
+    raise ImportError("scipy is required for kerchunking NetCDF3 files. Please install with `pip/conda install scipy`s")
 
 import fsspec
 


### PR DESCRIPTION
Based on https://github.com/conda-forge/kerchunk-feedstock/issues/4, I added more useful error messages if the needed (but not installed as dependencies) packages were not found. If this isn't useful or necessary feel free to close.