### PR TITLE
Added URLs to import errors

### DIFF
--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -5,7 +5,7 @@ import logging
 try:
     import cfgrib
 except ModuleNotFoundError as err:
-    if err.name == 'cfgrib': raise ImportError('cfgrib is needed to kerchunk GRIB2 files. Please install it with `conda install -c conda-forge cfgrib`')    
+    if err.name == 'cfgrib': raise ImportError('cfgrib is needed to kerchunk GRIB2 files. Please install it with `conda install -c conda-forge cfgrib`. See https://github.com/ecmwf/cfgrib for more details.')    
 
 import eccodes
 import fsspec

--- a/kerchunk/hdf.py
+++ b/kerchunk/hdf.py
@@ -12,7 +12,7 @@ from .codecs import FillStringsCodec
 try:
     import h5py
 except ModuleNotFoundError:
-    raise ImportError("h5py is required for kerchunking HDF5/NetCDF4 files. Please install with `pip/conda install h5py`")
+    raise ImportError("h5py is required for kerchunking HDF5/NetCDF4 files. Please install with `pip/conda install h5py`. See https://docs.h5py.org/en/latest/build.html for more details.")
 
 lggr = logging.getLogger("h5-to-zarr")
 _HIDDEN_ATTRS = {  # from h5netcdf.attrs

--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -6,7 +6,7 @@ import numpy as np
 try:
     from scipy.io.netcdf import ZERO, NC_VARIABLE, netcdf_file, netcdf_variable
 except ModuleNotFoundError:
-    raise ImportError("scipy is required for kerchunking NetCDF3 files. Please install with `pip/conda install scipy`")
+    raise ImportError("Scipy is required for kerchunking NetCDF3 files. Please install with `pip/conda install scipy`. See https://scipy.org/install/ for more details.")
 
 import fsspec
 


### PR DESCRIPTION
Had a thought this morning that it might be good to add the install docs URL for each package to the import errors.