### PR TITLE
Added ESIP tutorial notebook

### DIFF
--- a/docs/source/test_example.rst
+++ b/docs/source/test_example.rst
@@ -93,3 +93,8 @@ examples).
 Note that, if the combining was done previously and saved to a JSON file, then the path to
 it should replace ``out``, above, along with a ``target_options`` for any additional
 arguments fsspec might to access it
+
+Example/Tutorial Notebook
+================
+
+A set of tutorials notebooks, presented at the Earth Science Information Partners 2022 Winter Meeting, can be found at the following link, along with links to run the code on free cloud-based notebook environments: https://github.com/lsterzinger/2022-esip-kerchunk-tutorial

--- a/docs/source/test_example.rst
+++ b/docs/source/test_example.rst
@@ -95,6 +95,6 @@ it should replace ``out``, above, along with a ``target_options`` for any additi
 arguments fsspec might to access it
 
 Example/Tutorial Notebook
-================
+=========================
 
 A set of tutorials notebooks, presented at the Earth Science Information Partners 2022 Winter Meeting, can be found at the following link, along with links to run the code on free cloud-based notebook environments: https://github.com/lsterzinger/2022-esip-kerchunk-tutorial


### PR DESCRIPTION
I've gotten good feedback on the notebook I presented at ESIP's winter meeting, thought it might be worth including in the docs. I added it to the bottom of the "quick start" page but if you think there's a better place (or if we should have a dedicated page for interactive guides or something) I'm happy to move it