### PR TITLE
Fix gridding for regular_ll grib2 grid types

### DIFF
--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -175,10 +175,13 @@ def scan_grib(
                 _store_array(
                     store, z, data, name, inline_threshold, offset, size, attrs
                 )
+
             dims = (
                 ["x", "y"]
                 if m["gridType"] in cfgrib.dataset.GRID_TYPES_2D_NON_DIMENSION_COORDS
-                else ["longitude", "latitude"]
+                else ["latitude", "longitude"]
+                    if m["gridType"] in cfgrib.dataset.GRID_TYPES_DIMENSION_COORDS
+                    else ["longitude", "latitude"]
             )
             z[m["shortName"]].attrs["_ARRAY_DIMENSIONS"] = dims
 
@@ -201,10 +204,16 @@ def scan_grib(
                     else:
                         dims = [coord]
                         if coord == "latitude":
-                            x = x.reshape(vals.shape)[0].copy()
+                            if m["gridType"] in cfgrib.dataset.GRID_TYPES_DIMENSION_COORDS:
+                                x = x.reshape(vals.shape)[:,0].copy()
+                            else:
+                                x = x.reshape(vals.shape)[0].copy()
                             inline_extra = x.nbytes + 1
                         elif coord == "longitude":
-                            x = x.reshape(vals.shape)[:, 0].copy()
+                            if m["gridType"] in cfgrib.dataset.GRID_TYPES_DIMENSION_COORDS:
+                                x = x.reshape(vals.shape)[0].copy()
+                            else:
+                                x = x.reshape(vals.shape)[:,0].copy()
                             inline_extra = x.nbytes + 1
                 else:
                     x = np.array([x])

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -175,7 +175,6 @@ def scan_grib(
                 _store_array(
                     store, z, data, name, inline_threshold, offset, size, attrs
                 )
-
             dims = (
                 ["x", "y"]
                 if m["gridType"] in cfgrib.dataset.GRID_TYPES_2D_NON_DIMENSION_COORDS


### PR DESCRIPTION
See https://github.com/fsspec/kerchunk/issues/248 for discussion. 

`regular_ll` grid types in grib2 messages are (lat,lng) indexed