### PR TITLE
Fix for #248, #249, and #259, along with variable naming change

### DIFF
--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -161,8 +161,8 @@ def scan_grib(
                 + cfgrib.dataset.EXTRA_DATA_ATTRIBUTES_KEYS
                 if k in m
             }
-            ## try to use cfVarName if available,
-            ## otherwise use the grib shortName
+            # try to use cfVarName if available,
+            # otherwise use the grib shortName
             varName = m["cfVarName"]
             if varName in ("undef", "unknown"):
                 varName = m["shortName"]

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -177,11 +177,9 @@ def scan_grib(
                     store, z, data, name, inline_threshold, offset, size, attrs
                 )
             dims = (
-                ["x", "y"]
+                ["y", "x"]
                 if m["gridType"] in cfgrib.dataset.GRID_TYPES_2D_NON_DIMENSION_COORDS
                 else ["latitude", "longitude"]
-                if m["gridType"] in cfgrib.dataset.GRID_TYPES_DIMENSION_COORDS
-                else ["longitude", "latitude"]
             )
             z[m["shortName"]].attrs["_ARRAY_DIMENSIONS"] = dims
 
@@ -199,28 +197,15 @@ def scan_grib(
                         m["gridType"]
                         in cfgrib.dataset.GRID_TYPES_2D_NON_DIMENSION_COORDS
                     ):
-                        dims = ["x", "y"]
+                        dims = ["y", "x"]
                         x = x.reshape(vals.shape)
                     else:
                         dims = [coord]
                         if coord == "latitude":
-                            if (
-                                m["gridType"]
-                                in cfgrib.dataset.GRID_TYPES_DIMENSION_COORDS
-                            ):
-                                x = x.reshape(vals.shape)[:, 0].copy()
-                            else:
-                                x = x.reshape(vals.shape)[0].copy()
-                            inline_extra = x.nbytes + 1
+                            x = x.reshape(vals.shape)[:, 0].copy()
                         elif coord == "longitude":
-                            if (
-                                m["gridType"]
-                                in cfgrib.dataset.GRID_TYPES_DIMENSION_COORDS
-                            ):
-                                x = x.reshape(vals.shape)[0].copy()
-                            else:
-                                x = x.reshape(vals.shape)[:, 0].copy()
-                            inline_extra = x.nbytes + 1
+                            x = x.reshape(vals.shape)[0].copy()
+                        inline_extra = x.nbytes + 1
                 else:
                     x = np.array([x])
                     dims = [coord]

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -161,8 +161,13 @@ def scan_grib(
                 + cfgrib.dataset.EXTRA_DATA_ATTRIBUTES_KEYS
                 if k in m
             }
+            ## try to use cfVarName if available,
+            ## otherwise use the grib shortName
+            varName = m["cfVarName"]
+            if varName in ("undef", "unknown"):
+                varName = m["shortName"]
             _store_array(
-                store, z, vals, m["shortName"], inline_threshold, offset, size, attrs
+                store, z, vals, varName, inline_threshold, offset, size, attrs
             )
             if "typeOfLevel" in m and "level" in m:
                 name = m["typeOfLevel"]
@@ -181,7 +186,7 @@ def scan_grib(
                 if m["gridType"] in cfgrib.dataset.GRID_TYPES_2D_NON_DIMENSION_COORDS
                 else ["latitude", "longitude"]
             )
-            z[m["shortName"]].attrs["_ARRAY_DIMENSIONS"] = dims
+            z[varName].attrs["_ARRAY_DIMENSIONS"] = dims
 
             for coord in cfgrib.dataset.COORD_ATTRS:
                 coord2 = {"latitude": "latitudes", "longitude": "longitudes"}.get(


### PR DESCRIPTION
### About the Change
See #259 for discussion, and #249 for history of issue/changes being reverted or modified. 

In addition to the issues with the dimension labels being wrong, this PR includes a change to variable names passed to xarray. Xarray and cfgrib tend to use the ```cfVarName``` if its available, and then falls back to the grib ```shortName``` if its unavailable or unknown. This change should mean that xarray variable names are consistent across kerchunk/cfgrib/xarray. 