### PR TITLE
Fix bug in `combine.auto_dask`

### DIFF
--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -672,9 +672,9 @@ def auto_dask(
 
     # make delayed calls
     tasks = [single_task(u) for u in urls]
-    tasks_per_batch = len(tasks) // n_batches
+    tasks_per_batch = -(-len(tasks) // n_batches)
     tasks2 = []
-    for batch in range(tasks_per_batch + 1):
+    for batch in range(n_batches):
         in_tasks = tasks[batch * tasks_per_batch : (batch + 1) * tasks_per_batch]
         u = urls[batch * tasks_per_batch : (batch + 1) * tasks_per_batch]
         if in_tasks:

--- a/kerchunk/tests/test_combine_dask.py
+++ b/kerchunk/tests/test_combine_dask.py
@@ -10,7 +10,8 @@ from kerchunk.zarr import ZarrToZarr
 dask = pytest.importorskip("dask")
 
 
-def test_simplest(m):
+@pytest.mark.parametrize("n_batches", [1, 2, 3])
+def test_simplest(m, n_batches):
     for i in range(4):
         m.pipe(
             {
@@ -25,9 +26,9 @@ def test_simplest(m):
         [f"memory:///data{i}" for i in range(4)],
         single_driver=ZarrToZarr,
         single_kwargs={"inline": 0},
-        n_batches=2,
+        n_batches=n_batches,
         mzz_kwargs={
-            "coo_map": {"count": re.compile(".*(\d)")},
+            "coo_map": {"count": re.compile(r".*(\d)")},
             "inline_threshold": 0,
             "coo_dtypes": {"count": "i4"},
         },


### PR DESCRIPTION
Simple fix to a looping bug in `combine.auto_dask`. Includes modification of existing test that fails on pre-fix code.

Closes #306 