### PR TITLE
refs_to_dataframe() reference file count fix

### DIFF
--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -153,9 +153,7 @@ def refs_to_dataframe(
             for metakey in [".zarray", ".zattrs"]:
                 key = f"{field}/{metakey}"
                 _write_json(os.path.join(field_path, metakey), refs[key])
-            for i, ind in enumerate(
-                np.ndindex(tuple(np.ceil(chunk_sizes).astype(int)))
-            ):
+            for i, ind in enumerate(np.ndindex(tuple(chunk_sizes.astype(int)))):
                 chunk_id = ".".join([str(ix) for ix in ind])
                 key = f"{field}/{chunk_id}"
                 # Make note if expected number of chunks differs from actual

--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -1,12 +1,11 @@
 import base64
+import logging
+
 import numpy as np
 import ujson
-import os
 import pandas as pd
 import fsspec
 import zarr
-
-from kerchunk.utils import templateize
 
 
 # example from preffs's README'
@@ -19,6 +18,7 @@ df = pd.DataFrame(
         "raw": [None, None, b"data"],
     }
 )
+logger = logging.getLogger("kerchunk.df")
 
 
 def _proc_raw(r):
@@ -31,14 +31,14 @@ def _proc_raw(r):
 
 def get_variables(refs, consolidated=True):
     """Get list of variable names from references.
-
+    Finds the top-level prefixes in a reference set, corresponding to
+    the directory listing of the root for zarr.
     Parameters
     ----------
     refs : dict
         kerchunk references keys
     consolidated : bool
         Whether or not to add consolidated metadata key to references. (default True)
-
     Returns
     -------
     fields : list of str
@@ -59,14 +59,13 @@ def get_variables(refs, consolidated=True):
             fields.append(k)
     if consolidated and ".zmetadata" not in fields:
         zarr.consolidate_metadata(meta)
-        refs[".zmetadata"] = meta[".zmetadata"]
+        refs[".zmetadata"] = ujson.loads(meta[".zmetadata"])
         fields.append(".zmetadata")
     return fields
 
 
 def _normalize_json(json_obj):
     """Normalize json representation as bytes
-
     Parameters
     ----------
     json_obj : str, bytes, dict, list
@@ -79,9 +78,8 @@ def _normalize_json(json_obj):
     return json_obj
 
 
-def _write_json(fname, json_obj):
+def _write_json(fname, json_obj, storage_options=None):
     """Write references into a parquet file.
-
     Parameters
     ----------
     fname : str
@@ -89,25 +87,23 @@ def _write_json(fname, json_obj):
     json_obj : str, bytes, dict, list
         JSON data for parquet file to be written.
     """
+    storage_options = {} if storage_options is None else storage_options
     json_obj = _normalize_json(json_obj)
-    with open(fname, "wb") as f:
+    with fsspec.open(fname, "wb", **storage_options) as f:
         f.write(json_obj)
 
 
 def refs_to_dataframe(
     refs,
     url,
-    consolidated=True,
     storage_options=None,
-    row_group_size=1000,
-    compression="zstd",
-    engine="fastparquet",
+    record_size=10_000,
+    categorical_threshold=10,
     **kwargs,
 ):
     """Write references as a store of parquet files with multiple row groups.
     The directory structure should mimic a normal zarr store but instead of standard chunk
     keys, references are saved as parquet dataframes with multiple row groups.
-
     Parameters
     ----------
     refs: str | dict
@@ -117,248 +113,132 @@ def refs_to_dataframe(
     url: str
         Location for the output, together with protocol. This must be a writable
         directory.
-    consolidated : bool
-        Whether or not to add consolidated metadata key to references. (default True)
     storage_options: dict | None
         Passed to fsspec when for writing the parquet.
-    row_group_size : int
-        Number of references to store in each reference file (default 1000)
-    compression : str
-        Compression information to pass to parquet engine, default is zstd.
-    engine : {'fastparquet', 'pyarrow'}
-        Library to use for writing parquet files.
+    record_size : int
+        Number of references to store in each reference file (default 10000)
+    categorical_threshold : int
+        Encode urls as pandas.Categorical to reduce memory footprint if the ratio
+        of the number of unique urls to total number of refs for each variable
+        is greater than or equal to this number. (default 10)
     **kwargs : dict
-        Additional keyword arguments passed to parquet engine of choice.
+        Additional keyword arguments passed to fastparquet.
     """
-    if not os.path.exists(url):
-        os.makedirs(url)
     if "refs" in refs:
         refs = refs["refs"]
-    _write_json(
-        os.path.join(url, ".row_group_size"), dict(row_group_size=row_group_size)
-    )
-    fields = get_variables(refs, consolidated=consolidated)
+        
+    fs, _ = fsspec.core.url_to_fs(url)
+    fs.makedirs(url, exist_ok=True)
+    fields = get_variables(refs, consolidated=True)
+    # write into .zmetadata at top level, one fewer read on access
+    refs[".zmetadata"]['record_size'] = record_size
+
+    # Initialize arrays
+    paths = np.full(record_size, np.nan, dtype="O")
+    offsets = np.zeros(record_size, dtype="int64")
+    sizes = np.zeros(record_size, dtype="int64")
+    raws = np.full(record_size, np.nan, dtype="O")
     for field in fields:
-        field_path = os.path.join(url, field)
+        field_path = "/".join([url, field])
         if field.startswith("."):
             # zarr metadata keys (.zgroup, .zmetadata, etc)
-            _write_json(field_path, refs[field])
-        else:
-            if not os.path.exists(field_path):
-                os.makedirs(field_path)
-            # Read the variable zarray metadata to determine number of chunks
-            zarray = ujson.loads(refs[f"{field}/.zarray"])
-            chunk_sizes = np.ceil(
-                np.array(zarray["shape"]) / np.array(zarray["chunks"])
-            )
-            if chunk_sizes.size == 0:
-                chunk_sizes = np.array([0])
-            nchunks = int(np.product(chunk_sizes))
-            extra_rows = row_group_size - nchunks % row_group_size
-            output_size = nchunks + extra_rows
-            # Initialize dataframe columns. Don't know why but int64 gives better
-            # compression ratio than int32
-            paths = np.full(output_size, np.nan, dtype="O")
-            offsets = np.zeros(output_size, dtype="int64")
-            sizes = np.zeros(output_size, dtype="int64")
-            raws = np.full(output_size, np.nan, dtype="O")
-            nmissing = 0
-            for metakey in [".zarray", ".zattrs"]:
-                key = f"{field}/{metakey}"
-                _write_json(os.path.join(field_path, metakey), refs[key])
-            for i, ind in enumerate(np.ndindex(tuple(chunk_sizes.astype(int)))):
-                chunk_id = ".".join([str(ix) for ix in ind])
-                key = f"{field}/{chunk_id}"
-                # Make note if expected number of chunks differs from actual
-                # number found in references
-                if key in refs:
-                    data = refs[key]
-                    if isinstance(data, list):
-                        paths[i] = data[0]
-                        offsets[i] = data[1]
-                        sizes[i] = data[2]
-                    else:
-                        raws[i] = _proc_raw(data)
+            # only need to save .zmetadata
+            if field == '.zmetadata':
+                _write_json(field_path, refs[field], storage_options=storage_options)
+            continue
+
+        fs.makedirs(field_path, exist_ok=True)
+        # Read the variable zarray metadata to determine number of chunks
+        zarray = ujson.loads(refs[f"{field}/.zarray"])
+        chunk_sizes = np.ceil(np.array(zarray["shape"]) / np.array(zarray["chunks"]))
+        if chunk_sizes.size == 0:
+            chunk_sizes = np.array([0])
+        nchunks = int(np.product(chunk_sizes))
+        nrec = nchunks // record_size
+        rem = nchunks % record_size
+        nmissing = 0
+        nraw = 0
+        npath = 0
+        irec = 0
+        for i, ind in enumerate(np.ndindex(tuple(chunk_sizes.astype(int)))):
+            chunk_id = ".".join([str(ix) for ix in ind])
+            key = f"{field}/{chunk_id}"
+            # Last parquet record can be smaller than record_size
+            output_size = record_size if irec < nrec - 1 else rem
+            j = i % record_size
+            # Make note if expected number of chunks differs from actual
+            # number found in references
+            if key in refs:
+                data = refs[key]
+                if isinstance(data, list):
+                    npath += 1
+                    paths[j] = data[0]
+                    offsets[j] = data[1]
+                    sizes[j] = data[2]
                 else:
-                    nmissing += 1
-
-            if nmissing:
-                print(
-                    f"Warning: Chunks missing for field {field}. "
-                    f"Expected: {nchunks}, Found: {nchunks - nmissing}"
-                )
-            # The convention for parquet files is
-            # <url>/<field_name>/refs.parq
-            out_path = os.path.join(field_path, "refs.parq")
-            df = pd.DataFrame(
-                dict(path=paths, offset=offsets, size=sizes, raw=raws), copy=False
-            )
-            # Engine specific kwarg conventions. Set stats to false since
-            # those are currently unneeded.
-            if engine == "pyarrow":
-                # TODO: perhaps set some other defaults to pyarrow engine for
-                # optimization?
-                kwargs.update(write_statistics=False, row_group_size=row_group_size)
+                    nraw += 1
+                    raws[j] = _proc_raw(data)
             else:
-                kwargs.update(
-                    row_group_offsets=row_group_size,
-                    object_encoding=dict(raw="bytes", path="utf8"),
-                    has_nulls=["path", "raw"],
+                nmissing += 1
+            if j == output_size - 1:
+                # The convention for parquet files is
+                # <url>/<field_name>/refs.<rec_num>.parq
+                out_path = "/".join([field_path, f"refs.{irec}.parq"])
+                if nraw == output_size:
+                    # All raw refs, so we can drop path/offset/size
+                    df = pd.DataFrame(dict(raw=raws), copy=False)
+                    object_encoding = dict(raw="bytes")
+                    has_nulls = False
+                else:
+                    paths_maybe_cat = pd.Series(paths)
+                    nunique = paths_maybe_cat.nunique()
+                    if nunique and npath / nunique >= categorical_threshold:
+                        paths_maybe_cat = paths_maybe_cat.astype("category")
+                    if nraw == 0:
+                        # No raw refs
+                        df = pd.DataFrame(
+                            dict(path=paths_maybe_cat, offset=offsets, size=sizes), 
+                            copy=False
+                        )
+                        object_encoding = dict(path="utf8")
+                        has_nulls = ["path"] if npath != output_size else False
+                    else:
+                        df = pd.DataFrame(
+                            dict(path=paths_maybe_cat, offset=offsets, size=sizes,
+                                 raw=raws), 
+                            copy=False
+                        )
+                        object_encoding = dict(raw="bytes", path="utf8")
+                        has_nulls = ["path", "raw"]
+                        
+                # Subset df if selection is smaller than record size
+                if output_size != record_size:
+                    df = df.iloc[:output_size]
+                    
+                df.to_parquet(
+                    out_path,
+                    engine="fastparquet",
+                    storage_options=storage_options,
+                    compression="zstd",
+                    index=False,
                     stats=False,
+                    object_encoding=object_encoding,
+                    has_nulls=has_nulls,
+                    **kwargs,
                 )
-            df.to_parquet(
-                out_path,
-                engine=engine,
-                storage_options=storage_options,
-                compression=compression,
-                index=False,
-                **kwargs,
+                # Reinitialize arrays for next batch of refs to process.
+                paths[:] = np.nan
+                offsets[:] = 0
+                sizes[:] = 0
+                raws[:] = np.nan
+                irec += 1
+                nraw = 0
+                npath = 0
+
+        if nmissing:
+            # comment: missing keys are fine, so long as they are not a large fraction.
+            #  Does referenceFS successfully give FileNotFound for them?
+            logger.warning(
+                f"Warning: Chunks missing for field {field}. "
+                f"Expected: {nchunks}, Found: {nchunks - nmissing}"
             )
-
-
-def refs_to_dataframe_full(
-    refs,
-    url,
-    storage_options=None,
-    partition=False,
-    template_length=10,
-    dict_fraction=0.1,
-    min_refs=100,
-):
-    """Transform JSON/dict references to parquet storage
-
-    This function should produce much smaller on-disk size for any large reference set,
-    and much better memory footprint when loaded wih fsspec's DFReferenceFileSystem.
-
-    Parameters
-    ----------
-    refs: str | dict
-        Location of a JSON file containing references or a reference set already loaded
-        into memory. It will get processed by the standard referenceFS, to normalise
-        any templates, etc., it might contain.
-    url: str
-        Location for the output, together with protocol. If partition=True, this must
-        be a writable directory.
-    storage_options: dict | None
-        Passed to fsspec when for writing the parquet.
-    partition: bool
-        If True, split out the references into "metadata" and separate files for each of
-        the variables within the output directory.
-    template_length: int
-        Controls replacing a common prefix amongst reference URLs. If non-zero (in which
-        case no templating is done), finds and replaces the common prefix to URLs within
-        an output file (see :func:`kerchunk.utils.templateize`). If the URLs are
-        dict encoded, this step is not attempted.
-    dict_fraction: float
-        Use categorical/dict encoding if the number of unique URLs / total number of URLs
-        is is smaller than this number.
-    min_refs: int
-        If any variables have fewer entries than this number, they will be included in
-        "metadata" - this is typically the coordinates that you want loaded immediately
-        upon opening a dataset anyway. Ignored if partition is False.
-    """
-    # normalise refs (e.g., for templates)
-    fs = fsspec.filesystem("reference", fo=refs)
-    refs = fs.references
-
-    df = pd.DataFrame(
-        {
-            "key": list(refs),
-            # TODO: could get unique values using set() here and make categorical
-            #  columns with pd.Categorical.from_codes if it meets criterion
-            "path": [r[0] if isinstance(r, list) else None for r in refs.values()],
-            "offset": [
-                r[1] if isinstance(r, list) and len(r) > 1 else 0 for r in refs.values()
-            ],
-            "size": pd.Series(
-                [
-                    r[2] if isinstance(r, list) and len(r) > 1 else 0
-                    for r in refs.values()
-                ],
-                dtype="int32",
-            ),
-            "raw": [
-                _proc_raw(r) if not isinstance(r, list) else None for r in refs.values()
-            ],
-        }
-    )
-    # recoup memory
-    fs.clear_instance_cache()
-    del fs, refs
-
-    if partition is False:
-        templates = None
-        haspath = ~df["path"].isna()
-        nhaspath = haspath.sum()
-        if (
-            dict_fraction
-            and nhaspath
-            and (df["path"][haspath].nunique() / haspath.sum()) < dict_fraction
-        ):
-            df["path"] = df["path"].astype("category")
-        elif template_length:
-            templates, urls = templateize(
-                df["path"][haspath], min_length=template_length
-            )
-            df.loc[haspath, "path"] = urls
-        df.to_parquet(
-            url,
-            storage_options=storage_options,
-            index=False,
-            object_encoding={"raw": "bytes", "key": "utf8", "path": "utf8"},
-            stats=["key"],
-            has_nulls=["path", "raw"],
-            compression="zstd",
-            engine="fastparquet",
-            custom_metadata=templates or None,
-        )
-    else:
-        ismeta = df.key.str.contains(".z")
-        extra_inds = []
-        gb = df[~ismeta].groupby(df.key.map(lambda s: s.split("/", 1)[0]))
-        prefs = {"metadata"}
-        for prefix, subdf in gb:
-            if len(subdf) < min_refs:
-                ind = ismeta[~ismeta].iloc[gb.indices[prefix]].index
-                extra_inds.extend(ind.tolist())
-                prefs.add(prefix)
-                continue
-            subdf["key"] = subdf.key.str.slice(len(prefix) + 1, None)
-            templates = None
-            haspath = ~subdf["path"].isna()
-            nhaspath = haspath.sum()
-            if (
-                dict_fraction
-                and nhaspath
-                and (subdf["path"][haspath].nunique() / haspath.sum()) < dict_fraction
-            ):
-                subdf["path"] = subdf["path"].astype("category")
-            elif template_length:
-                templates, urls = templateize(
-                    subdf["path"][haspath], min_length=template_length
-                )
-                subdf.loc[haspath, "path"] = urls
-
-            subdf.to_parquet(
-                f"{url}/{prefix}.parq",
-                storage_options=storage_options,
-                index=False,
-                object_encoding={"raw": "bytes", "key": "utf8", "path": "utf8"},
-                stats=["key"],
-                has_nulls=["path", "raw"],
-                compression="zstd",
-                engine="fastparquet",
-                custom_metadata=templates or None,
-            )
-        ismeta[extra_inds] = True
-        df[ismeta].to_parquet(
-            f"{url}/metadata.parq",
-            storage_options=storage_options,
-            index=False,
-            object_encoding={"raw": "bytes", "key": "utf8", "path": "utf8"},
-            stats=["key"],
-            has_nulls=["path", "raw"],
-            compression="zstd",
-            engine="fastparquet",
-            custom_metadata={"prefs": str(prefs)},
-        )

--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -18,6 +18,7 @@ df = pd.DataFrame(
         "raw": [None, None, b"data"],
     }
 )
+
 logger = logging.getLogger("kerchunk.df")
 
 
@@ -41,7 +42,7 @@ def get_variables(refs, consolidated=True):
         kerchunk references keys
     consolidated : bool
         Whether or not to add consolidated metadata key to references. (default True)
-        
+
     Returns
     -------
     fields : list of str
@@ -69,7 +70,7 @@ def get_variables(refs, consolidated=True):
 
 def _normalize_json(json_obj):
     """Normalize json representation as bytes
-    
+
     Parameters
     ----------
     json_obj : str, bytes, dict, list
@@ -84,7 +85,7 @@ def _normalize_json(json_obj):
 
 def _write_json(fname, json_obj, storage_options=None):
     """Write references into a parquet file.
-    
+
     Parameters
     ----------
     fname : str

--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -180,8 +180,9 @@ def refs_to_dataframe(
                 if isinstance(data, list):
                     npath += 1
                     paths[j] = data[0]
-                    offsets[j] = data[1]
-                    sizes[j] = data[2]
+                    if len(data) > 1:
+                        offsets[j] = data[1]
+                        sizes[j] = data[2]
                 else:
                     nraw += 1
                     raws[j] = _proc_raw(data)

--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -31,14 +31,17 @@ def _proc_raw(r):
 
 def get_variables(refs, consolidated=True):
     """Get list of variable names from references.
+
     Finds the top-level prefixes in a reference set, corresponding to
     the directory listing of the root for zarr.
+
     Parameters
     ----------
     refs : dict
         kerchunk references keys
     consolidated : bool
         Whether or not to add consolidated metadata key to references. (default True)
+
     Returns
     -------
     fields : list of str
@@ -66,6 +69,7 @@ def get_variables(refs, consolidated=True):
 
 def _normalize_json(json_obj):
     """Normalize json representation as bytes
+
     Parameters
     ----------
     json_obj : str, bytes, dict, list
@@ -80,6 +84,7 @@ def _normalize_json(json_obj):
 
 def _write_json(fname, json_obj, storage_options=None):
     """Write references into a parquet file.
+
     Parameters
     ----------
     fname : str
@@ -101,22 +106,24 @@ def refs_to_dataframe(
     categorical_threshold=10,
     **kwargs,
 ):
-    """Write references as a store of parquet files with multiple row groups.
+    """Write references as a parquet files store.
+
     The directory structure should mimic a normal zarr store but instead of standard chunk
-    keys, references are saved as parquet dataframes with multiple row groups.
+    keys, references are saved as parquet dataframes.
+
     Parameters
     ----------
     refs: str | dict
         Location of a JSON file containing references or a reference set already loaded
-        into memory. It will get processed by the standard referenceFS, to normalise
-        any templates, etc., it might contain.
+        into memory.
     url: str
         Location for the output, together with protocol. This must be a writable
         directory.
     storage_options: dict | None
         Passed to fsspec when for writing the parquet.
     record_size : int
-        Number of references to store in each reference file (default 10000)
+        Number of references to store in each reference file (default 10000). Bigger values
+        mean fewer read requests but larger memory footprint.
     categorical_threshold : int
         Encode urls as pandas.Categorical to reduce memory footprint if the ratio
         of the number of unique urls to total number of refs for each variable
@@ -126,12 +133,12 @@ def refs_to_dataframe(
     """
     if "refs" in refs:
         refs = refs["refs"]
-        
+
     fs, _ = fsspec.core.url_to_fs(url)
     fs.makedirs(url, exist_ok=True)
     fields = get_variables(refs, consolidated=True)
     # write into .zmetadata at top level, one fewer read on access
-    refs[".zmetadata"]['record_size'] = record_size
+    refs[".zmetadata"]["record_size"] = record_size
 
     # Initialize arrays
     paths = np.full(record_size, np.nan, dtype="O")
@@ -143,7 +150,7 @@ def refs_to_dataframe(
         if field.startswith("."):
             # zarr metadata keys (.zgroup, .zmetadata, etc)
             # only need to save .zmetadata
-            if field == '.zmetadata':
+            if field == ".zmetadata":
                 _write_json(field_path, refs[field], storage_options=storage_options)
             continue
 
@@ -197,24 +204,28 @@ def refs_to_dataframe(
                     if nraw == 0:
                         # No raw refs
                         df = pd.DataFrame(
-                            dict(path=paths_maybe_cat, offset=offsets, size=sizes), 
-                            copy=False
+                            dict(path=paths_maybe_cat, offset=offsets, size=sizes),
+                            copy=False,
                         )
                         object_encoding = dict(path="utf8")
                         has_nulls = ["path"] if npath != output_size else False
                     else:
                         df = pd.DataFrame(
-                            dict(path=paths_maybe_cat, offset=offsets, size=sizes,
-                                 raw=raws), 
-                            copy=False
+                            dict(
+                                path=paths_maybe_cat,
+                                offset=offsets,
+                                size=sizes,
+                                raw=raws,
+                            ),
+                            copy=False,
                         )
                         object_encoding = dict(raw="bytes", path="utf8")
                         has_nulls = ["path", "raw"]
-                        
+
                 # Subset df if selection is smaller than record size
                 if output_size != record_size:
                     df = df.iloc[:output_size]
-                    
+
                 df.to_parquet(
                     out_path,
                     engine="fastparquet",
@@ -236,8 +247,6 @@ def refs_to_dataframe(
                 npath = 0
 
         if nmissing:
-            # comment: missing keys are fine, so long as they are not a large fraction.
-            #  Does referenceFS successfully give FileNotFound for them?
             logger.warning(
                 f"Warning: Chunks missing for field {field}. "
                 f"Expected: {nchunks}, Found: {nchunks - nmissing}"

--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -41,6 +41,7 @@ def get_variables(refs, consolidated=True):
         kerchunk references keys
     consolidated : bool
         Whether or not to add consolidated metadata key to references. (default True)
+        
     Returns
     -------
     fields : list of str
@@ -68,6 +69,7 @@ def get_variables(refs, consolidated=True):
 
 def _normalize_json(json_obj):
     """Normalize json representation as bytes
+    
     Parameters
     ----------
     json_obj : str, bytes, dict, list
@@ -82,6 +84,7 @@ def _normalize_json(json_obj):
 
 def _write_json(fname, json_obj, storage_options=None):
     """Write references into a parquet file.
+    
     Parameters
     ----------
     fname : str

--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -213,7 +213,6 @@ def refs_to_dataframe(
                         has_nulls = ["path"] if npath != output_size else False
                     else:
                         df = pd.DataFrame(
-
                             dict(
                                 path=paths_maybe_cat,
                                 offset=offsets,

--- a/kerchunk/tests/test_df.py
+++ b/kerchunk/tests/test_df.py
@@ -30,13 +30,14 @@ def test_1():
 
     # no raw
     assert df0.to_dict() == {
-        "offset": {0: 0, 1: 10, 2: 0},
+        "offset": {0: 0, 1: 10, 2: 0, 3: 0},
         "path": {
             0: "memory://url1.file",
             1: "memory://url1.file",
             2: "memory://url2.file",
+            3: "memory://url3.file",
         },
-        "size": {0: 0, 1: 100, 2: 0},
+        "size": {0: 0, 1: 100, 2: 0, 3: 0},
     }
 
     # with raw column


### PR DESCRIPTION
@martindurant This adds a quick fix to `df.py` so that the total number of reference parquet files is now counted correctly per the changes introduced in #298. Without it the 2nd to last file may have an incomplete number of references included.