### PR TITLE
Support urls as references input to refs_to_dataframe

### DIFF
--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -143,8 +143,7 @@ def refs_to_dataframe(
     if isinstance(fo, str):
         # JSON file
         dic = dict(**(target_options or {}), protocol=target_protocol)
-        ref_fs, fo = fsspec.core.url_to_fs(fo, **dic)
-        with ref_fs.open(fo, "rb") as f:
+        with fsspec.open(fo, "rb", **dic) as f:
             logger.info("Read reference from URL %s", fo)
             refs = ujson.load(f)
     else:


### PR DESCRIPTION
Tested with:

```python
url = 's3://esip/noaa/nwm/grid1km/LDAS_combined.json'
target_options = dict(anon=True, skip_instance_cache=True, 
                                     client_kwargs={'endpoint_url':'https://ncsa.osn.xsede.org'})
refs_to_dataframe(url, 'test_parq', target_protocol='s3', target_options=target_options)