### PR TITLE
Use H5Dchunk_iter to get chunk information from HDF5 files

### DIFF
--- a/kerchunk/hdf.py
+++ b/kerchunk/hdf.py
@@ -520,10 +520,22 @@ class SingleHdf5ToZarr:
             # Go over all the dataset chunks...
             stinfo = dict()
             chunk_size = dset.chunks
-            for index in range(num_chunks):
-                blob = dsid.get_chunk_info(index)
-                key = tuple([a // b for a, b in zip(blob.chunk_offset, chunk_size)])
-                stinfo[key] = {"offset": blob.byte_offset, "size": blob.size}
+
+            def get_key(blob):
+                return tuple([a // b for a, b in zip(blob.chunk_offset, chunk_size)])
+
+            def store_chunk_info(blob):
+                stinfo[get_key(blob)] = \
+                    {"offset": blob.byte_offset, "size": blob.size}
+
+            has_chunk_iter = callable(getattr(dsid, "chunk_iter", None))
+
+            if has_chunk_iter:
+                dsid.chunk_iter(store_chunk_info)
+            else:
+                for index in range(num_chunks):
+                    store_chunk_info(dsid.get_chunk_info(index))
+
             return stinfo
 
 

--- a/kerchunk/hdf.py
+++ b/kerchunk/hdf.py
@@ -525,8 +525,7 @@ class SingleHdf5ToZarr:
                 return tuple([a // b for a, b in zip(blob.chunk_offset, chunk_size)])
 
             def store_chunk_info(blob):
-                stinfo[get_key(blob)] = \
-                    {"offset": blob.byte_offset, "size": blob.size}
+                stinfo[get_key(blob)] = {"offset": blob.byte_offset, "size": blob.size}
 
             has_chunk_iter = callable(getattr(dsid, "chunk_iter", None))
 


### PR DESCRIPTION
# Use H5Dchunk_iter to get chunk information from HDF5 files

This pull request makes chunk information retrieval from HDF5 files more efficient, especially when more than 16K chunks are involved. Translation times drop from tens of seconds to fractions of a second.

Fix #286 

Here we replace `dsid.get_chunk_info` with `dsid.chunk_iter` which is available with HDF5 1.14.0 and will soon be available with HDF5 1.12.3. The HDF5 C call is [`H5Dchunk_iter`](https://docs.hdfgroup.org/hdf5/develop/group___h5_d.html#title6).

The is particularly more efficient with a large number of chunks.

## Before this pull request: N^2 scaling with the number of chunks
With 16,384 chunks translating takes 13 seconds. With 32,768 chunks, twice as many chunks, translating takes 74 seconds.

```python
In [1]: import kerchunk.hdf, fsspec, h5py

In [2]: with h5py.File("pytest.h5", "w") as f:
   ...:     dset = f.create_dataset("test", (1024*2,1024*2), chunks=(16,16))
   ...:     dset[:] = 1
   ...:     print(dset.id.get_num_chunks())
   ...:
16384

In [3]: %%time
   ...: with fsspec.open("pytest.h5") as inf:
   ...:     h5chunks = kerchunk.hdf.SingleHdf5ToZarr(inf, "pytest.h5", inline_threshold=100)
   ...:     h5chunks.translate()
   ...:
CPU times: user 13.3 s, sys: 6.91 ms, total: 13.3 s
Wall time: 13.3 s

In [4]: with h5py.File("pytest.h5", "w") as f:
   ...:     dset = f.create_dataset("test", (1024*4,1024*2), chunks=(16,16))
   ...:     dset[:] = 1
   ...:     print(dset.id.get_num_chunks())
   ...:
32768

In [5]: %%time
   ...: with fsspec.open("pytest.h5") as inf:
   ...:     h5chunks = kerchunk.hdf.SingleHdf5ToZarr(inf, "pytest.h5", inline_threshold=100)
   ...:     h5chunks.translate()
   ...:
CPU times: user 1min 14s, sys: 34.1 ms, total: 1min 14s
Wall time: 1min 14s

In [6]: with h5py.File("pytest.h5", "w") as f:
   ...:     dset = f.create_dataset("test", (1024*4,1024*4), chunks=(16,16))
   ...:     dset[:] = 1
   ...:     print(dset.id.get_num_chunks())
   ...: 
65536

In [7]: %%time
   ...: with fsspec.open("pytest.h5") as inf:
   ...:     h5chunks = kerchunk.hdf.SingleHdf5ToZarr(inf, "pytest.h5", inline_threshold=100)
   ...:     h5chunks.translate()
   ...: 

CPU times: user 6min 33s, sys: 275 ms, total: 6min 33s
Wall time: 6min 33s


```

## After this pull request: Linear scaling with the number of chunks

With 16,384 chunks, translating takes 0.131 seconds. With 32,768 chunks, twice as many chunks, translating takes 0.214 seconds.

```python
In [1]: import kerchunk.hdf, fsspec, h5py

In [2]: with h5py.File("pytest.h5", "w") as f:
   ...:     dset = f.create_dataset("test", (1024*2,1024*2), chunks=(16,16))
   ...:     dset[:] = 1
   ...:     print(dset.id.get_num_chunks())
   ...: 
16384

In [3]: %%time
   ...: with fsspec.open("pytest.h5") as inf:
   ...:     h5chunks = kerchunk.hdf.SingleHdf5ToZarr(inf, "pytest.h5", inline_threshold=100)
   ...:     h5chunks.translate()
   ...: 
CPU times: user 131 ms, sys: 23.8 ms, total: 155 ms
Wall time: 154 ms

In [4]: with h5py.File("pytest.h5", "w") as f:
   ...:     dset = f.create_dataset("test", (1024*4,1024*2), chunks=(16,16))
   ...:     dset[:] = 1
   ...:     print(dset.id.get_num_chunks())
   ...: 
32768

In [5]: %%time
   ...: with fsspec.open("pytest.h5") as inf:
   ...:     h5chunks = kerchunk.hdf.SingleHdf5ToZarr(inf, "pytest.h5", inline_threshold=100)
   ...:     h5chunks.translate()
   ...: 
CPU times: user 214 ms, sys: 4.39 ms, total: 218 ms
Wall time: 217 ms

In [6]: with h5py.File("pytest.h5", "w") as f:
   ...:     dset = f.create_dataset("test", (1024*4,1024*4), chunks=(16,16))
   ...:     dset[:] = 1
   ...:     print(dset.id.get_num_chunks())
   ...: 
65536

In [7]: %%time
   ...: with fsspec.open("pytest.h5") as inf:
   ...:     h5chunks = kerchunk.hdf.SingleHdf5ToZarr(inf, "pytest.h5", inline_threshold=100)
   ...:     h5chunks.translate()
   ...: 
CPU times: user 472 ms, sys: 32.4 ms, total: 504 ms
Wall time: 503 ms
```

## Summary

Time for `SingleHdf5ToZarr.translate()`:

| Number of Chunks | Before this pull request, with `get_chunk_info` | After this pull request, with `chunk_iter` |Ratio |
|---|---|---|---|
| 16,384 | 13 seconds | 0.131 seconds | 99x |
| 32,768 | 74 seconds | 0.214 seconds |346x |
| 65,536 | 393 seconds | 0.472 seconds | 832x |