### PR TITLE
Ensure `inline_array` keeps attributes

### DIFF
--- a/kerchunk/tests/test_utils.py
+++ b/kerchunk/tests/test_utils.py
@@ -70,12 +70,16 @@ def test_inline_array():
 """,
         "data/0": b"\x01\x00\x00\x00",
         "data/1": b"\x02\x00\x00\x00",
+        'data/.zattrs': '{"_ARRAY_DIMENSIONS":["Longitude","nv"],"comment":"longitude '
+                        'values at the west and east bounds of each '
+                        'pixel.","units":"degrees_east"}',
     }
     fs = fsspec.filesystem("reference", fo=refs)
     out1 = kerchunk.utils.inline_array(refs, threshold=1000)  # does nothing
     assert out1 == refs
     out2 = kerchunk.utils.inline_array(refs, threshold=1000, names=["data"])  # explicit
     assert "data/1" not in out2
+    assert out2["data/.zattrs"] == refs["data/.zattrs"]
     fs = fsspec.filesystem("reference", fo=out2)
     g = zarr.open(fs.get_mapper())
     assert g.data[:].tolist() == [1, 2]

--- a/kerchunk/tests/test_utils.py
+++ b/kerchunk/tests/test_utils.py
@@ -70,9 +70,9 @@ def test_inline_array():
 """,
         "data/0": b"\x01\x00\x00\x00",
         "data/1": b"\x02\x00\x00\x00",
-        'data/.zattrs': '{"_ARRAY_DIMENSIONS":["Longitude","nv"],"comment":"longitude '
-                        'values at the west and east bounds of each '
-                        'pixel.","units":"degrees_east"}',
+        "data/.zattrs": '{"_ARRAY_DIMENSIONS":["Longitude","nv"],"comment":"longitude '
+        "values at the west and east bounds of each "
+        'pixel.","units":"degrees_east"}',
     }
     fs = fsspec.filesystem("reference", fo=refs)
     out1 = kerchunk.utils.inline_array(refs, threshold=1000)  # does nothing

--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -170,7 +170,8 @@ def _inline_array(group, threshold, names, prefix=""):
             cond1 = threshold and thing.nbytes < threshold and thing.nchunks > 1
             cond2 = prefix1 in names
             if cond1 or cond2:
-                group.create_dataset(
+                original_attrs = dict(thing.attrs)
+                arr = group.create_dataset(
                     name=name,
                     dtype=thing.dtype,
                     shape=thing.shape,
@@ -179,6 +180,7 @@ def _inline_array(group, threshold, names, prefix=""):
                     compression=None,
                     overwrite=True,
                 )
+                arr.attrs.update(original_attrs)
 
 
 def inline_array(store, threshold=1000, names=None, remote_options=None):


### PR DESCRIPTION
Currently `inline_array` won't keep attrs around for arrays that it inlines. This PR makes sure attrs are preserved. 

cc @martindurant 