### PR TITLE
Handle padding in netcdf3 translation

### DIFF
--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -207,9 +207,15 @@ class NetCDF3ToZarr(netcdf_file):
             outer_shape = size // dt.itemsize
             offset = start
             for name in dt.names:
+                dtype = dt[name]
+
+                # Skip padding, but increment offset.
+                if name.startswith("_padding_"):
+                    offset += dtype.itemsize
+                    continue
+
                 # the order of the names if fixed and important!
                 var = self.variables[name]
-                dtype = dt[name]
                 base = dtype.base  # actual dtype
                 shape = (outer_shape,) + dtype.shape
 


### PR DESCRIPTION
#365 

The padding was not being handled, so the translation crashed because it was not an actual variable. This PR skips the padding but makes sure to increment the offset for each padding chunk encountered.