### PR TITLE
Adds check to ensure `consolidated=True` is not passed to open_dataset

### DIFF
--- a/kerchunk/xarray_backend.py
+++ b/kerchunk/xarray_backend.py
@@ -56,4 +56,4 @@ def open_reference_dataset(
 
     m = fsspec.get_mapper("reference://", fo=filename_or_obj, **storage_options)
 
-    return xr.open_dataset(m, engine="zarr", consolidated=False, **open_dataset_options)
+    return xr.open_dataset(m, engine="zarr", **open_dataset_options)

--- a/kerchunk/xarray_backend.py
+++ b/kerchunk/xarray_backend.py
@@ -48,6 +48,12 @@ def open_reference_dataset(
     if open_dataset_options is None:
         open_dataset_options = {}
 
+    if open_dataset_options.get("consolidated"):
+        raise ValueError(
+            "consolidated = True is not supported when opening Kerchunk reference files through Xarray."
+        )
+    open_dataset_options["consolidated"] = False
+
     m = fsspec.get_mapper("reference://", fo=filename_or_obj, **storage_options)
 
     return xr.open_dataset(m, engine="zarr", consolidated=False, **open_dataset_options)


### PR DESCRIPTION
This pr is an tiny addition to https://github.com/fsspec/kerchunk/pull/372#event-10713351822. 