### PR TITLE
Fix tests following change to LazyReferenceMapper

### DIFF
--- a/kerchunk/df.py
+++ b/kerchunk/df.py
@@ -152,7 +152,10 @@ def refs_to_dataframe(
 
     fs, _ = fsspec.core.url_to_fs(url, **(storage_options or {}))
     out = LazyReferenceMapper.create(
-        record_size, root=url, fs=fs, categorical_threshold=categorical_threshold
+        record_size=record_size,
+        root=url,
+        fs=fs,
+        categorical_threshold=categorical_threshold,
     )
 
     for k in sorted(refs):

--- a/kerchunk/tests/test_combine.py
+++ b/kerchunk/tests/test_combine.py
@@ -310,7 +310,7 @@ def test_lazy_filler(tmpdir, refs):
 
     fs = fsspec.filesystem("file")
     tmpdir = str(tmpdir)
-    out = LazyReferenceMapper.create(10, tmpdir, fs)
+    out = LazyReferenceMapper.create(record_size=10, root=tmpdir, fs=fs)
 
     mzz = MultiZarrToZarr(
         [refs["single1"], refs["single2"]],


### PR DESCRIPTION
Fixes #396 

The change upstream was necessary, since the record_size now has a sensible default value, but the root path is still required.