### PR TITLE
add deps for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
     "s3fs",
     "types-ujson",
     "xarray",
+    "cfgrib",
+    "scipy",
+    "netcdf4"
 ]
 
 [project.urls]


### PR DESCRIPTION
Add all dependencies for testing to the dev group.
Is there a better way to install all?



This should allow an update to the docs for [running the test suite ](https://fsspec.github.io/kerchunk/contributing.html#running-the-test-suite)
```console
pip install .[dev]
pytest kerchunk
```

Should `pip install -e .` install all these dependencies? Is this because I am using venv (not anaconda :cry:)?
Without explicitly installing the dev dependencies I don't have pytest and without adding the other dependencies (there are currently optional dependency groups for all but netcdf4), I can run the test suite.


Examples
```
_______________________________________________________________________ ERROR collecting external/kerchunk/kerchunk/tests/test_xarray_backend.py ________________________________________________________________________
ImportError while importing test module '/home/builder/bando/external/kerchunk/kerchunk/tests/test_xarray_backend.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
venv/lib/python3.10/site-packages/kerchunk/netCDF3.py:12: in <module>
    from scipy.io._netcdf import ZERO, NC_VARIABLE, netcdf_file, netcdf_variable
E   ModuleNotFoundError: No module named 'scipy'

During handling of the above exception, another exception occurred:
/usr/local/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
kerchunk/tests/test_xarray_backend.py:3: in <module>
    from kerchunk import netCDF3
venv/lib/python3.10/site-packages/kerchunk/netCDF3.py:14: in <module>
    raise ImportError(
E   ImportError: Scipy is required for kerchunking NetCDF3 files. Please install with `pip/conda install scipy`. See https://scipy.org/install/ for more details.
```

```
    @pytest.fixture()
    def matching_coordinate_dimension_dataset(tmpdir):
        """Create a dataset with a coordinate dimension that matches the name of a
        variable dimension."""
        # https://unidata.github.io/netcdf4-python/#creatingopeningclosing-a-netcdf-file
>       from netCDF4 import Dataset
E       ModuleNotFoundError: No module named 'netCDF4'

kerchunk/tests/test_netcdf.py:104: ModuleNotFoundError
```



