### PR TITLE
Add grib_tree method

### DIFF
--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -7,6 +7,7 @@ dependencies:
   - dask
   - zarr
   - xarray
+  - xarray-datatree
   - h5netcdf
   - h5py<3.9
   - pandas

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -7,6 +7,7 @@ dependencies:
   - dask
   - zarr
   - xarray
+  - xarray-datatree
   - h5netcdf
   - h5py<3.9
   - pandas

--- a/ci/environment-py39.yml
+++ b/ci/environment-py39.yml
@@ -7,6 +7,7 @@ dependencies:
   - dask
   - zarr
   - xarray
+  - xarray-datatree
   - h5netcdf
   - h5py<3.9
   - pandas

--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -328,9 +328,6 @@ class MultiZarrToZarr:
             )
             if k in z:
                 # copy attributes if values came from an original variable
-                logger.warning(
-                    "Zarr attrs: %s", {ii: vv for ii, vv in z[k].attrs.items()}
-                )
                 arr.attrs.update(z[k].attrs)
             arr.attrs["_ARRAY_DIMENSIONS"] = [k]
             if self.cf_units and k in self.cf_units:

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -366,7 +366,9 @@ def grib_tree(
     remote_options=None,
 ) -> Dict:
     """
-    Build a hierarchical data model from a set of scanned grib messages. The iterable input groups should
+    Build a hierarchical data model from a set of scanned grib messages. 
+    
+    The iterable input groups should
     be a collection of results from scan_grib. Multiple grib files can be processed together to produce an
     FMRC like collection.
     The time (reference_time) and step coordinates will be used as concat_dims in the MultiZarrToZarr

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -396,6 +396,7 @@ def grib_tree(
     # Hard code the filters in the correct order for the group hierarchy
     filters = ["stepType", "typeOfLevel"]
 
+    # TODO allow passing a LazyReferenceMapper as output?
     zarr_store = {}
     zroot = zarr.open_group(store=zarr_store)
     result = dict(refs=zarr_store)

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -526,7 +526,9 @@ def grib_tree(
 
 def correct_hrrr_subhf_step(group: Dict) -> Dict:
     """
-    Overrides the definition of the step variable. Sets the value equal to the `valid_time - time`
+    Overrides the definition of the "step" variable. 
+    
+    Sets the value equal to the `valid_time - time`
     in hours as a floating point value. This fixes issues with the HRRR SubHF grib2 step as read by
     cfgrib via scan_grib.
     The result is a deep copy, the original data is unmodified.

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -379,9 +379,16 @@ def grib_tree(
     Grib steps that are missing due to WrongStepUnitError are patched with NaT
     The input message_groups should not be modified by this method
 
-    :param message_groups: a collection of zarr store like dictionaries as produced by scan_grib
-    :param remote_options: remote options to pass to ZarrToMultiZarr
-    :return: A new zarr store like dictionary for use as a reference filesystem mapper with zarr
+    Parameters
+    ----------
+    message_groups: iterable[dict]
+        a collection of zarr store like dictionaries as produced by scan_grib
+    remote_options: dict
+        remote options to pass to ZarrToMultiZarr
+
+    Returns
+    -------
+    list(dict): A new zarr store like dictionary for use as a reference filesystem mapper with zarr
     or xarray datatree
     """
     from kerchunk.combine import MultiZarrToZarr
@@ -516,14 +523,22 @@ def grib_tree(
     return result
 
 
-def correct_hrrr_subhf_step(group: dict) -> dict:
+def correct_hrrr_subhf_step(group: Dict) -> Dict:
     """
     Overrides the definition of the step variable. Sets the value equal to the `valid_time - time`
     in hours as a floating point value. This fixes issues with the HRRR SubHF grib2 step as read by
     cfgrib via scan_grib.
     The result is a deep copy, the original data is unmodified.
-    :param group: the zarr group store for a single grib message
-    :return: a new deep copy of the corrected zarr group store
+
+    Parameters
+    ----------
+    group: dict
+        the zarr group store for a single grib message
+
+    Returns
+    -------
+    dict: A new zarr store like dictionary for use as a reference filesystem mapper with zarr
+    or xarray datatree
     """
     group = copy.deepcopy(group)
     group["refs"]["step/.zarray"] = (

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from kerchunk.utils import class_factory, _encode_for_JSON
 from kerchunk.codecs import GRIBCodec
+from kerchunk.combine import MultiZarrToZarr, drop
 
 
 # cfgrib copies over certain GRIB attributes
@@ -334,8 +335,6 @@ def example_combine(
     ...        "consolidated": False,
     ...        "storage_options": {"fo": tot, "remote_options": {"anon": True}}})
     """
-    from kerchunk.combine import MultiZarrToZarr, drop
-
     files = [
         "s3://noaa-hrrr-bdp-pds/hrrr.20190101/conus/hrrr.t22z.wrfsfcf01.grib2",
         "s3://noaa-hrrr-bdp-pds/hrrr.20190101/conus/hrrr.t23z.wrfsfcf01.grib2",
@@ -391,8 +390,6 @@ def grib_tree(
     list(dict): A new zarr store like dictionary for use as a reference filesystem mapper with zarr
     or xarray datatree
     """
-    from kerchunk.combine import MultiZarrToZarr
-
     # Hard code the filters in the correct order for the group hierarchy
     filters = ["stepType", "typeOfLevel"]
 
@@ -526,8 +523,8 @@ def grib_tree(
 
 def correct_hrrr_subhf_step(group: Dict) -> Dict:
     """
-    Overrides the definition of the "step" variable. 
-    
+    Overrides the definition of the "step" variable.
+
     Sets the value equal to the `valid_time - time`
     in hours as a floating point value. This fixes issues with the HRRR SubHF grib2 step as read by
     cfgrib via scan_grib.

--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -366,11 +366,10 @@ def grib_tree(
     remote_options=None,
 ) -> Dict:
     """
-    Build a hierarchical data model from a set of scanned grib messages. 
-    
-    The iterable input groups should
-    be a collection of results from scan_grib. Multiple grib files can be processed together to produce an
-    FMRC like collection.
+    Build a hierarchical data model from a set of scanned grib messages.
+
+    The iterable input groups should be a collection of results from scan_grib. Multiple grib files can
+    be processed together to produce an FMRC like collection.
     The time (reference_time) and step coordinates will be used as concat_dims in the MultiZarrToZarr
     aggregation. Each variable name will become a group with nested subgroups representing the grib
     step type and grib level. The resulting hierarchy can be opened as a zarr_group or a xarray datatree.
@@ -421,7 +420,9 @@ def grib_tree(
             # If you process the groups from a single file in order, you can use the msg# to compare with the
             # IDX file.
             logger.warning(
-                "Found unknown variable in msg# %s... it will be dropped", msg_ind
+                "Dropping unknown variable in msg# %d. Compare with the grib idx file to identify and build"
+                " a ecCodes local grib definitions to fix it.",
+                msg_ind,
             )
             unknown_counter += 1
             continue

--- a/kerchunk/tests/hrrr.wrfsfcf.subset.json
+++ b/kerchunk/tests/hrrr.wrfsfcf.subset.json
@@ -1,0 +1,776 @@
+[
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        3769472,
+        778132
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "\u0000\u0000\u0000\u0000\u0000@o@",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        3769472,
+        778132
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        3769472,
+        778132
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        5336183,
+        758639
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAADAckA=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        5336183,
+        758639
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        5336183,
+        758639
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        9129785,
+        583526
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "\u0000\u0000\u0000\u0000\u0000@\u007f@",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        9129785,
+        583526
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        9129785,
+        583526
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        12933260,
+        594926
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAADghUA=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        12933260,
+        594926
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        12933260,
+        594926
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        16552535,
+        603844
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAACQikA=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        16552535,
+        603844
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        16552535,
+        603844
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        19553501,
+        607146
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAADojEA=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        19553501,
+        607146
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        19553501,
+        607146
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        22494249,
+        613972
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAABAj0A=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        22494249,
+        613972
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        22494249,
+        613972
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"heightAboveGround latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        25995311,
+        1088857
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"heightAboveGround\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "heightAboveGround/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "heightAboveGround/0": "\u0000\u0000\u0000\u0000\u0000\u0000T@",
+      "heightAboveGround/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"height above the surface\",\"positive\":\"up\",\"standard_name\":\"height\",\"units\":\"m\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        25995311,
+        1088857
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        25995311,
+        1088857
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        75116763,
+        597663
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        75116763,
+        597663
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        75116763,
+        597663
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        3715881,
+        771149
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "\u0000\u0000\u0000\u0000\u0000@o@",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        3715881,
+        771149
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        3715881,
+        771149
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        5255070,
+        759884
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAADAckA=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        5255070,
+        759884
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        5255070,
+        759884
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        8998771,
+        585301
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "\u0000\u0000\u0000\u0000\u0000@\u007f@",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        8998771,
+        585301
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        8998771,
+        585301
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        13360764,
+        599767
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAADghUA=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        13360764,
+        599767
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        13360764,
+        599767
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        16982674,
+        607352
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAACQikA=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        16982674,
+        607352
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        16982674,
+        607352
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        19963771,
+        611356
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAADojEA=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        19963771,
+        611356
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        19963771,
+        611356
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"isobaricInhPa latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        22911345,
+        615501
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"isobaricInhPa\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "isobaricInhPa/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "isobaricInhPa/0": "base64:AAAAAABAj0A=",
+      "isobaricInhPa/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"pressure\",\"positive\":\"down\",\"standard_name\":\"air_pressure\",\"stored_direction\":\"decreasing\",\"units\":\"hPa\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        22911345,
+        615501
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        22911345,
+        615501
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"heightAboveGround latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        33570344,
+        1113546
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"heightAboveGround\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "heightAboveGround/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "heightAboveGround/0": "\u0000\u0000\u0000\u0000\u0000\u0000T@",
+      "heightAboveGround/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"height above the surface\",\"positive\":\"up\",\"standard_name\":\"height\",\"units\":\"m\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        33570344,
+        1113546
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        33570344,
+        1113546
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        84922638,
+        149193
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        84922638,
+        149193
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        84922638,
+        149193
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsfcf01.grib2"
+    }
+  }
+]

--- a/kerchunk/tests/hrrr.wrfsubhf.subset.json
+++ b/kerchunk/tests/hrrr.wrfsubhf.subset.json
@@ -1,0 +1,644 @@
+[
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"heightAboveGround latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        3653893,
+        1088857
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"heightAboveGround\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "heightAboveGround/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "heightAboveGround/0": "\u0000\u0000\u0000\u0000\u0000\u0000T@",
+      "heightAboveGround/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"height above the surface\",\"positive\":\"up\",\"standard_name\":\"height\",\"units\":\"m\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        3653893,
+        1088857
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        3653893,
+        1088857
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        23103704,
+        387589
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"avg\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        23103704,
+        387589
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        23103704,
+        387589
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        30668850,
+        597663
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        30668850,
+        597663
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        30668850,
+        597663
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:ENAUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf00.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"heightAboveGround latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        3562657,
+        1095473
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"heightAboveGround\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "heightAboveGround/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "heightAboveGround/0": "\u0000\u0000\u0000\u0000\u0000\u0000T@",
+      "heightAboveGround/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"height above the surface\",\"positive\":\"up\",\"standard_name\":\"height\",\"units\":\"m\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        3562657,
+        1095473
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        3562657,
+        1095473
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000.@",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:lNMUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        23247353,
+        371150
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"avg\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        23247353,
+        371150
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        23247353,
+        371150
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:lNMUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        30856504,
+        514649
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        30856504,
+        514649
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        30856504,
+        514649
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000.@",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:lNMUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"heightAboveGround latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        46412956,
+        1098403
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"heightAboveGround\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "heightAboveGround/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "heightAboveGround/0": "\u0000\u0000\u0000\u0000\u0000\u0000T@",
+      "heightAboveGround/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"height above the surface\",\"positive\":\"up\",\"standard_name\":\"height\",\"units\":\"m\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        46412956,
+        1098403
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        46412956,
+        1098403
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000>@",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:GNcUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        66130542,
+        262115
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"avg\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        66130542,
+        262115
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        66130542,
+        262115
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000>@",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:GNcUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        73418573,
+        386739
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        73418573,
+        386739
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        73418573,
+        386739
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000>@",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:GNcUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"heightAboveGround latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        88359532,
+        1105040
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"heightAboveGround\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "heightAboveGround/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "heightAboveGround/0": "\u0000\u0000\u0000\u0000\u0000\u0000T@",
+      "heightAboveGround/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"height above the surface\",\"positive\":\"up\",\"standard_name\":\"height\",\"units\":\"m\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        88359532,
+        1105040
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        88359532,
+        1105040
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAACARkA=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:nNoUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        108165133,
+        172091
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"avg\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        108165133,
+        172091
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        108165133,
+        172091
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAACARkA=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:nNoUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        115335065,
+        240444
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        115335065,
+        240444
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        115335065,
+        240444
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAACARkA=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:nNoUZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"heightAboveGround latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "u/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"u\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "u/0.0": [
+        "{{u}}",
+        129691270,
+        1113546
+      ],
+      "u/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"eastward_wind\",\"GRIB_cfVarName\":\"u\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"U component of wind\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":131,\"GRIB_shortName\":\"u\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"heightAboveGround\",\"GRIB_units\":\"m s**-1\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"U component of wind\",\"standard_name\":\"eastward_wind\",\"units\":\"m s**-1\"}",
+      "heightAboveGround/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "heightAboveGround/0": "\u0000\u0000\u0000\u0000\u0000\u0000T@",
+      "heightAboveGround/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"height above the surface\",\"positive\":\"up\",\"standard_name\":\"height\",\"units\":\"m\"}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        129691270,
+        1113546
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        129691270,
+        1113546
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        149322652,
+        147580
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"avg\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        149322652,
+        147580
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        149322652,
+        147580
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "\u0000\u0000\u0000\u0000\u0000\u0000N@",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  },
+  {
+    "version": 1,
+    "refs": {
+      ".zgroup": "{\"zarr_format\":2}",
+      ".zattrs": "{\"GRIB_centre\":\"kwbc\",\"GRIB_centreDescription\":\"US National Weather Service - NCEP \",\"GRIB_edition\":2,\"GRIB_subCentre\":0,\"coordinates\":\"surface latitude longitude step time valid_time\",\"institution\":\"US National Weather Service - NCEP \"}",
+      "dswrf/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"dswrf\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "dswrf/0.0": [
+        "{{u}}",
+        156408715,
+        149193
+      ],
+      "dswrf/.zattrs": "{\"GRIB_DxInMetres\":3000.0,\"GRIB_DyInMetres\":3000.0,\"GRIB_LaDInDegrees\":38.5,\"GRIB_Latin1InDegrees\":38.5,\"GRIB_Latin2InDegrees\":38.5,\"GRIB_LoVInDegrees\":262.5,\"GRIB_NV\":0,\"GRIB_Nx\":1799,\"GRIB_Ny\":1059,\"GRIB_cfName\":\"unknown\",\"GRIB_cfVarName\":\"dswrf\",\"GRIB_dataType\":\"fc\",\"GRIB_gridDefinitionDescription\":\"Lambert Conformal can be secant or tangent, conical or bipolar\",\"GRIB_gridType\":\"lambert\",\"GRIB_iScansNegatively\":0,\"GRIB_jPointsAreConsecutive\":0,\"GRIB_jScansPositively\":1,\"GRIB_latitudeOfFirstGridPointInDegrees\":21.138123,\"GRIB_latitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_longitudeOfFirstGridPointInDegrees\":237.280472,\"GRIB_longitudeOfSouthernPoleInDegrees\":0.0,\"GRIB_missingValue\":3.4028234663852886e+38,\"GRIB_name\":\"Downward short-wave radiation flux\",\"GRIB_numberOfPoints\":1905141,\"GRIB_paramId\":260087,\"GRIB_shortName\":\"dswrf\",\"GRIB_stepType\":\"instant\",\"GRIB_stepUnits\":1,\"GRIB_typeOfLevel\":\"surface\",\"GRIB_units\":\"W m**-2\",\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"Downward short-wave radiation flux\",\"standard_name\":\"unknown\",\"units\":\"W m**-2\"}",
+      "surface/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "surface/0": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+      "surface/.zattrs": "{\"_ARRAY_DIMENSIONS\":[]}",
+      "latitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"latitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "latitude/0.0": [
+        "{{u}}",
+        156408715,
+        149193
+      ],
+      "latitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"latitude\",\"standard_name\":\"latitude\",\"units\":\"degrees_north\"}",
+      "longitude/.zarray": "{\"chunks\":[1059,1799],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":[{\"dtype\":\"float64\",\"id\":\"grib\",\"var\":\"longitude\"}],\"order\":\"C\",\"shape\":[1059,1799],\"zarr_format\":2}",
+      "longitude/0.0": [
+        "{{u}}",
+        156408715,
+        149193
+      ],
+      "longitude/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"y\",\"x\"],\"long_name\":\"longitude\",\"standard_name\":\"longitude\",\"units\":\"degrees_east\"}",
+      "step/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<f8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "step/0": "base64:AAAAAAAA8D8=",
+      "step/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"long_name\":\"time since forecast_reference_time\",\"standard_name\":\"forecast_period\",\"units\":\"hours\"}",
+      "time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "time/0": "base64:ENAUZQAAAAA=",
+      "time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"initial time of forecast\",\"standard_name\":\"forecast_reference_time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}",
+      "valid_time/.zarray": "{\"chunks\":[],\"compressor\":null,\"dtype\":\"<i8\",\"fill_value\":null,\"filters\":null,\"order\":\"C\",\"shape\":[],\"zarr_format\":2}",
+      "valid_time/0": "base64:IN4UZQAAAAA=",
+      "valid_time/.zattrs": "{\"_ARRAY_DIMENSIONS\":[],\"calendar\":\"proleptic_gregorian\",\"long_name\":\"time\",\"standard_name\":\"time\",\"units\":\"seconds since 1970-01-01T00:00:00\"}"
+    },
+    "templates": {
+      "u": "testdata/hrrr.t01z.wrfsubhf01.grib2"
+    }
+  }
+]

--- a/kerchunk/tests/test_grib.py
+++ b/kerchunk/tests/test_grib.py
@@ -103,8 +103,8 @@ def test_grib_tree():
     result = grib_tree(corrected_msg_groups)
     fs = fsspec.filesystem("reference", fo=result)
     zg = zarr.open_group(fs.get_mapper(""))
-    isinstance(zg["refc/instant/atmosphere/refc"], zarr.Array)
-    isinstance(zg["vbdsf/avg/surface/vbdsf"], zarr.Array)
+    assert isinstance(zg["refc/instant/atmosphere/refc"], zarr.Array)
+    assert isinstance(zg["vbdsf/avg/surface/vbdsf"], zarr.Array)
     assert (
         zg["vbdsf/avg/surface"].attrs["coordinates"]
         == "surface latitude longitude time valid_time step"

--- a/kerchunk/tests/test_grib.py
+++ b/kerchunk/tests/test_grib.py
@@ -4,8 +4,8 @@ import fsspec
 import numpy as np
 import pytest
 import xarray as xr
-
-from kerchunk.grib2 import scan_grib, _split_file, GribToZarr
+import zarr
+from kerchunk.grib2 import scan_grib, _split_file, GribToZarr, grib_tree
 
 cfgrib = pytest.importorskip("cfgrib")
 here = os.path.dirname(__file__)
@@ -83,3 +83,17 @@ def test_subhourly():
     fpath = os.path.join(here, "hrrr.wrfsubhf.sample.grib2")
     result = scan_grib(fpath)
     assert len(result) == 2, "Expected two grib messages"
+
+
+def test_grib_tree():
+    """
+    Additional testing here would be good.
+    Maybe add json files with scan_grib output?
+    """
+    fpath = os.path.join(here, "hrrr.wrfsubhf.sample.grib2")
+    scanned_msg_groups = scan_grib(fpath)
+    result = grib_tree(scanned_msg_groups)
+    fs = fsspec.filesystem("reference", fo=result)
+    zg = zarr.open_group(fs.get_mapper(""))
+    isinstance(zg["refc/instant/atmosphere/refc"], zarr.Array)
+    isinstance(zg["vbdsf/avg/surface/vbdsf"], zarr.Array)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "s3fs",
     "types-ujson",
     "xarray",
+    "xarray-datatree",
     "cfgrib",
     "scipy",
     "netcdf4"


### PR DESCRIPTION
# Add an method to map grib2 data model to zarr hierarchy & xarray datatree

The method is opinionated about how to do this - there are many possible ways. I hope the is generally useful enough that it is worth adding to the kerchunk library.

See examples in [Colab](https://colab.research.google.com/drive/1fhNZYF5vhMBD7vuK9Kgmt50IUr_77kZE?usp=sharing)

Here is an example of the hierarchical structure for the eastward wind velocity variable which has been aggregated by step, time and level (isobaricInhPa).

<img width="576" alt="Screenshot 2023-11-29 at 11 19 14 PM" src="https://github.com/fsspec/kerchunk/assets/84335963/87caf265-13fb-4b64-9911-cd7fc453676d">


