### PR TITLE
Ensuring that ZarrToZarr metadata is inlined

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,34 +12,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    # Standard drop-in approach that should work for most people.
-    - uses: ammaraskar/sphinx-action@master
+    - uses: mamba-org/setup-micromamba@v1
       with:
-        docs-folder: "docs/"
-    # # Example of using a custom build-command.
-    # - uses: ammaraskar/sphinx-action@master
-    #   with:
-    #     build-command: "sphinx-build -b html . _build"
-    #     docs-folder: "docs2/"
-    # # Grabbing custom dependencies and building as a pdf.
-    # - uses: ammaraskar/sphinx-action@master
-    #   with:
-    #     pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
-    #     build-command: "make latexpdf"
-    #     docs-folder: "docs2/"
-    # # Great extra actions to compose with:
-    # # Create an artifact of the html output.
-    # - uses: actions/upload-artifact@v1
-    #   with:
-    #     name: DocumentationHTML
-    #     path: docs/_build/html/
-    # # Create an artifact out of the previously built pdf.
-    # - uses: actions/upload-artifact@v1
-    #   with:
-    #     name: Documentation
-    #     path: docs2/_build/latex/pdfexample.pdf
-    # Publish built docs to gh-pages branch.
-    # ===============================
+        environment-file: ci/environment-docs.yml
+    - name: make docs
+      shell: bash -l {0}
+      run: |
+        cd docs
+        make html
     - name: Commit documentation changes
       run: |
         git clone https://github.com/fsspec/kerchunk.git --branch gh-pages --single-branch gh-pages
@@ -58,4 +38,3 @@ jobs:
         branch: gh-pages
         directory: gh-pages
         github_token: ${{ secrets.GITHUB_TOKEN }}
-    # ===============================

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,4 +10,5 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
+        pre-build-command: "pip install docutils>=0.18.1"
         path: docs/build/html/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,8 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: ammaraskar/sphinx-action@master
+    - uses: mamba-org/setup-micromamba@v1
       with:
-        docs-folder: "docs/"
-        pre-build-command: "pip install docutils>=0.18.1"
-        path: docs/build/html/
+        environment-file: ci/environment-docs.yml
+    - name: make docs
+      shell: bash -l {0}
+      run: |
+        cd docs
+        make html

--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -1,0 +1,35 @@
+name: test_env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.10
+  - dask
+  - zarr
+  - xarray
+  - xarray-datatree
+  - h5netcdf
+  - h5py<3.9
+  - pandas
+  - cfgrib
+  - cftime
+  - astropy
+  - requests
+  - aiohttp
+  - pytest-cov
+  - fsspec
+  - dask
+  - scipy
+  - s3fs
+  - python-blosc
+  - flake8
+  - black
+  - fastparquet
+  - pip
+  - pyopenssl
+  - tifffile
+  - netCDF4
+  - sphinx
+  - numpydoc
+  - sphinx-rtd-theme
+  - autodoc

--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -32,4 +32,3 @@ dependencies:
   - sphinx
   - numpydoc
   - sphinx-rtd-theme
-  - autodoc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx-rtd-theme
-numpydoc==1.2.1
+numpydoc
 autodoc
 numpy
 fsspec

--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -135,7 +135,7 @@ def _encode_for_JSON(store):
 
 
 def do_inline(store, threshold, remote_options=None, remote_protocol=None):
-    """Replace short chunks with the value of that chunk
+    """Replace short chunks with the value of that chunk and inline metadata
 
     The chunk may need encoding with base64 if not ascii, so actual
     length may be larger than threshold.
@@ -147,10 +147,20 @@ def do_inline(store, threshold, remote_options=None, remote_protocol=None):
         remote_protocol=remote_protocol,
     )
     out = fs.references.copy()
+
+    # Inlining is done when one of two conditions are satisfied:
+    # 1. The item is small enough, i.e. smaller than the threshold specified in the function call
+    # 2. The item is a metadata file, i.e. a .z* file
     get_keys = [
         k
         for k, v in out.items()
-        if isinstance(v, list) and len(v) == 3 and v[2] < threshold
+        if (isinstance(v, list) and len(v) == 3 and v[2] < threshold)
+        or (
+            isinstance(v, list)
+            and len(v) == 1
+            and isinstance(v[0], str)
+            and v[0].split("/")[-1].startswith(".z")
+        )
     ]
     values = fs.cat(get_keys)
     for k, v in values.items():

--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -199,7 +199,7 @@ def _inline_array(group, threshold, names, prefix=""):
 
 
 def inline_array(store, threshold=1000, names=None, remote_options=None):
-    """Inline whole arrays by threshold or name, repace with a single metadata chunk
+    """Inline whole arrays by threshold or name, replace with a single metadata chunk
 
     Inlining whole arrays results in fewer keys. If the constituent keys were
     already inlined, this also results in a smaller file overall. No action is taken

--- a/kerchunk/zarr.py
+++ b/kerchunk/zarr.py
@@ -40,11 +40,11 @@ def single_zarr(
             refs[k] = mapper[k]
         else:
             refs[k] = [fsspec.utils._unstrip_protocol(mapper._key_to_str(k), mapper.fs)]
-    # from kerchunk.utils import do_inline
-    # inline_threshold = inline or inline_threshold
-    # if inline_threshold:
-    #     # this never does anything since we don't have the chunk sizes
-    #     refs = do_inline(refs, inline_threshold, remote_options=storage_options)
+    from kerchunk.utils import do_inline
+
+    inline_threshold = inline or inline_threshold
+    if inline_threshold:
+        refs = do_inline(refs, inline_threshold, remote_options=storage_options)
     if isinstance(refs, LazyReferenceMapper):
         refs.flush()
     return refs


### PR DESCRIPTION
## Fix for ZarrToZarr Metadata Inlining

Previously (#402), using `ZarrToZarr` before `MultiZarrtoZarr` would cause an issue since the metadata files weren't inlined in the references as they are in the other scanners. This forces the metadata files to be inlined so that it the assumptions within `MultiZarrtoZarr` hold.

The do_inline function in utils.py will now inline when a user has generated references from ZarrToZarr which is now consistent with the other scanners

Resolves #402