### PR TITLE
Update LazyReferenceMapper.create() syntax in docs

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -167,16 +167,18 @@ one go and may be faster, if you have a Dask cluster available.
    fs = fsspec.filesystem("file")
 
    os.makedirs("combined.parq")
-   out = LazyReferenceMapper.create(1000, "combined.parq", fs)
+   out = LazyReferenceMapper.create(record_size=1000, root="combined.parq", fs=fs)
 
    # Create references from input files
    single_ref_sets = [hdf.SingleHdf5ToZarr(_).translate() for _ in files]
 
    out_dict = MultiZarrToZarr(
     single_ref_sets,
-    remote_protocol="memory",
+    remote_protocol="s3",
     concat_dims=["time"],
-    out=out).translate()
+    remote_options={"anon": True},
+    out=out
+    ).translate()
 
    out.flush()
 


### PR DESCRIPTION
Updates docs for https://github.com/fsspec/filesystem_spec/pull/1420, and updates remote_protocol to `s3` to make parameter meaning more obvious.

Relates to https://github.com/fsspec/kerchunk/issues/412