### PR TITLE
Update CI testing

### DIFF
--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -9,7 +9,7 @@ dependencies:
   - xarray
   - xarray-datatree
   - h5netcdf
-  - h5py<3.9
+  - h5py
   - pandas
   - cfgrib
   - cftime

--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -9,7 +9,7 @@ dependencies:
   - xarray
   - xarray-datatree
   - h5netcdf
-  - h5py<3.9
+  - h5py
   - pandas
   - cfgrib
   - cftime

--- a/ci/environment-py311.yml
+++ b/ci/environment-py311.yml
@@ -9,7 +9,7 @@ dependencies:
   - xarray
   - xarray-datatree
   - h5netcdf
-  - h5py<3.9
+  - h5py
   - pandas
   - cfgrib
   - cftime


### PR DESCRIPTION
In working on #446 (#450) and #448 (#451), I have discovered that some of these issue has to do with changes in dependencies (e.g., Xarray and eccodes).  These issues have also cause some tests to fail and other tests to be invalid because of the upstream changes.  This PR attempts to update the tests to meet the expectations of the newest upstream dependencies.