### PR TITLE
Explicitly calculate dtype element size in netCDF3 records

### DIFF
--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -412,7 +412,6 @@ class MultiZarrToZarr:
                 elif k in z:
                     # Fall back to existing fill value
                     kw["fill_value"] = z[k].fill_value
-
             arr = group.create_dataset(
                 name=k,
                 data=data,

--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -285,7 +285,11 @@ class NetCDF3ToZarr(netcdf_file):
             }
         )
         if self.threshold:
-            out = inline_array(out, self.threshold, remote_options=self.storage_options)
+            out = inline_array(
+                out,
+                self.threshold,
+                remote_options=dict(remote_options=self.storage_options),
+            )
 
         if isinstance(out, LazyReferenceMapper):
             out.flush()

--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -232,7 +232,8 @@ class NetCDF3ToZarr(netcdf_file):
             # native chunks version (no codec, no options)
             start, size, dt = self.chunks["record_array"][0]
             dt = np.dtype(dt)
-            outer_shape = size // dt.itemsize
+            itemsize = sum(dt[_].itemsize for _ in dt.names)
+            outer_shape = size // itemsize
             offset = start
             for name in dt.names:
                 dtype = dt[name]

--- a/kerchunk/tests/test_grib.py
+++ b/kerchunk/tests/test_grib.py
@@ -123,7 +123,7 @@ def test_grib_tree():
         "atmosphere latitude longitude step time valid_time".split()
     )
     # Assert that the fill value is set correctly
-    assert zg.refc.instant.atmosphere.step.fill_value is np.NaN
+    assert zg.refc.instant.atmosphere.step.fill_value is np.nan
 
 
 # The following two tests use json fixture data generated from calling scan grib

--- a/kerchunk/tests/test_utils.py
+++ b/kerchunk/tests/test_utils.py
@@ -1,6 +1,7 @@
 import io
 
 import fsspec
+import json
 import kerchunk.utils
 import kerchunk.zarr
 import numpy as np
@@ -72,16 +73,16 @@ def test_inline_array():
         "data/.zattrs": '{"foo": "bar"}',
     }
     fs = fsspec.filesystem("reference", fo=refs)
-    out1 = kerchunk.utils.inline_array(refs, threshold=1000)  # does nothing
+    out1 = kerchunk.utils.inline_array(refs, threshold=1)  # does nothing
     assert out1 == refs
-    out2 = kerchunk.utils.inline_array(refs, threshold=1000, names=["data"])  # explicit
+    out2 = kerchunk.utils.inline_array(refs, threshold=1, names=["data"])  # explicit
     assert "data/1" not in out2
-    assert out2["data/.zattrs"] == refs["data/.zattrs"]
+    assert json.loads(out2["data/.zattrs"]) == json.loads(refs["data/.zattrs"])
     fs = fsspec.filesystem("reference", fo=out2)
     g = zarr.open(fs.get_mapper())
     assert g.data[:].tolist() == [1, 2]
 
-    out3 = kerchunk.utils.inline_array(refs, threshold=1)  # inlines because of size
+    out3 = kerchunk.utils.inline_array(refs, threshold=1000)  # inlines because of size
     assert "data/1" not in out3
     fs = fsspec.filesystem("reference", fo=out3)
     g = zarr.open(fs.get_mapper())

--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -194,6 +194,7 @@ def _inline_array(group, threshold, names, prefix=""):
                     chunks=thing.shape,
                     compression=None,
                     overwrite=True,
+                    fill_value=thing.fill_value,
                 )
                 arr.attrs.update(original_attrs)
 

--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -182,7 +182,7 @@ def _inline_array(group, threshold, names, prefix=""):
         if isinstance(thing, zarr.Group):
             _inline_array(thing, threshold=threshold, prefix=prefix1, names=names)
         else:
-            cond1 = threshold and thing.nbytes < threshold and thing.nchunks > 1
+            cond1 = threshold and thing.nbytes < threshold
             cond2 = prefix1 in names
             if cond1 or cond2:
                 original_attrs = dict(thing.attrs)
@@ -277,7 +277,7 @@ def subchunk(store, variable, factor):
     if multi:
         # TODO: this reloads the referenceFS; *maybe* reuses it
         return subchunk(store, variable, multi)
-    breakpoint()
+
     # execute
     meta["chunks"] = chunk_new
     store = copy.deepcopy(store)


### PR DESCRIPTION
Fixes #465 

@rsignell-usgs please test. Not what I thought was happening. I don't know why I can't trust numpy's `dt.itemsize`.