### PR TITLE
Tolerate Zarr V3 module path name change

### DIFF
--- a/kerchunk/hdf.py
+++ b/kerchunk/hdf.py
@@ -7,7 +7,6 @@ import fsspec.core
 from fsspec.implementations.reference import LazyReferenceMapper
 import numpy as np
 import zarr
-from zarr.meta import encode_fill_value
 import numcodecs
 
 from .codecs import FillStringsCodec
@@ -21,6 +20,12 @@ except ModuleNotFoundError:  # pragma: no cover
         "`pip/conda install h5py`. See https://docs.h5py.org/en/latest/build.html "
         "for more details."
     )
+
+try:
+    from zarr.meta import encode_fill_value
+except ModuleNotFoundError:
+    # https://github.com/zarr-developers/zarr-python/issues/2021
+    from zarr.v2.meta import encode_fill_value
 
 lggr = logging.getLogger("h5-to-zarr")
 _HIDDEN_ATTRS = {  # from h5netcdf.attrs


### PR DESCRIPTION
The `encode_fill_value` function was moved into a new module in the latest version of `zarr`, and this causes a problem for packages that depend on both `zarr==3.0.0` and `kerchunk`, such as VirtualiZarr. I don't think this is necessarily related to https://github.com/fsspec/kerchunk/pull/292 , but that PR is free to cherry-pick this commit because they probably should be a single pull request.