### PR TITLE
Add Zarr compatibility functions

### DIFF
--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -11,9 +11,9 @@ import zarr
 
 try:
     import zarr.array
-    ZARR_VERSION = 3
+    _ZARR_VERSION = 3
 except:
-    ZARR_VERSION = 2
+    _ZARR_VERSION = 2
 
 
 
@@ -61,7 +61,7 @@ def consolidate(refs):
     return {"version": 1, "refs": out}
 
 def encode_fill_value(v, dtype, object_codec=None):
-    if ZARR_VERSION == 3:
+    if _ZARR_VERSION == 3:
         # Precarious use of this function
         # https://github.com/zarr-developers/zarr-python/issues/2021
         # https://github.com/zarr-developers/VirtualiZarr/pull/182#discussion_r1673096418
@@ -133,24 +133,24 @@ def rename_target_files(
     with fsspec.open(url_out, mode="wt", **(storage_options_out or {})) as f:
         ujson.dump(new, f)
 
-def zarr_init_group_and_store(store=None, zarr_format=2):
-    if ZARR_VERSION == 3 and zarr_format == 2:
+def zarr_init_group_and_store(store=None, zarr_version=2):
+    if _ZARR_VERSION == 3 and zarr_version == 2:
         from zarr.v2.hierarchy import group
         store = store or {}
         return group(store, overwrite=True), store
-    elif ZARR_VERSION == 3 and zarr_format == 3:
+    elif _ZARR_VERSION == 3 and zarr_version == 3:
         from zarr.store import StorePath, MemoryStore
         store = store or StorePath(MemoryStore(mode="w"))
         return zarr.group(store, overwrite=True), store
-    elif ZARR_VERSION == 2 and zarr_format == 2:
+    elif _ZARR_VERSION == 2 and zarr_version == 2:
         store = store or {}
         return zarr.group(store, overwrite=True), store
     else:
         raise ValueError("Initializing V3 stores requires zarr>=3")
 
-def _encode_for_JSON(store, zarr_format=2):
+def _encode_for_JSON(store, zarr_version=2):
     """Make store JSON encodable"""
-    if ZARR_VERSION == 2 or zarr_format == 2:
+    if _ZARR_VERSION == 2 or zarr_version == 2:
         store = store.copy()
     else:
         store = fsspec.asyn.sync(fsspec.asyn.get_loop(), store.store.to_dict_with_copy)


### PR DESCRIPTION
This is a continuation of https://github.com/fsspec/kerchunk/pull/475 because I identified that there are several more behavior changes in zarr v3. Going forward, the `utils.py` file will abstract away the differences between ZarrV2 and ZarrV3 depending on what the user has installed.

Note that @jhamman's PR https://github.com/fsspec/kerchunk/pull/292 may now be outdated, though I'll merge those commits into this PR if its desired to expose a `zarr_version` to kerchunk callers.