### PR TITLE
Allow disabling inlining for MultiZarrToZarr

### DIFF
--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -94,7 +94,7 @@ class MultiZarrToZarr:
         If True, will load the references specified by out and add to them rather than starting
         from scratch. Assumes the same coordinates are being concatenated.
     """
-    
+
     inline: int
 
     def __init__(

--- a/kerchunk/combine.py
+++ b/kerchunk/combine.py
@@ -1,7 +1,7 @@
 import collections.abc
 import logging
 import re
-from typing import List, Optional
+from typing import List
 import warnings
 
 import fsspec
@@ -78,9 +78,8 @@ class MultiZarrToZarr:
     :param remote_protocol: str
         The protocol of the original data
     :param remote_options: dict
-    :param inline_threshold: int | None
-        Size below which binary blocks are included directly in the output. If None, no
-        inlining is done.
+    :param inline_threshold: int
+        Size below which binary blocks are included directly in the output
     :param preprocess: callable
         Acts on the references dict of all inputs before processing. See ``drop()``
         for an example.
@@ -95,6 +94,8 @@ class MultiZarrToZarr:
         If True, will load the references specified by out and add to them rather than starting
         from scratch. Assumes the same coordinates are being concatenated.
     """
+    
+    inline: int
 
     def __init__(
         self,
@@ -107,7 +108,7 @@ class MultiZarrToZarr:
         target_options=None,
         remote_protocol=None,
         remote_options=None,
-        inline_threshold: Optional[int] = 500,
+        inline_threshold: int = 500,
         preprocess=None,
         postprocess=None,
         out=None,
@@ -586,7 +587,7 @@ class MultiZarrToZarr:
 
                     ref = fs.references.get(fn)
                     if (
-                        self.inline is not None
+                        self.inline > 0
                         and isinstance(ref, list)
                         and (
                             (len(ref) > 1 and ref[2] < self.inline)

--- a/kerchunk/tests/test_combine.py
+++ b/kerchunk/tests/test_combine.py
@@ -769,7 +769,7 @@ def test_inline(refs):
 
 
 def test_no_inline(refs):
-    """Ensure that inline_threshold=None disables MultiZarrToZarr checking file size."""
+    """Ensure that inline_threshold=0 disables MultiZarrToZarr checking file size."""
     ds = xr.Dataset(dict(x=[1, 2, 3]))
     ds["y"] = 3 + ds["x"]
     store = fsspec.get_mapper("memory://zarr_store")
@@ -779,7 +779,7 @@ def test_no_inline(refs):
     # kerchunk.zarr.single_zarr or equivalently ZarrToZarr.translate.
     ref["refs"]["y/0"] = ["file:///tmp/some/data-that-shouldnt-be-accessed"]
 
-    mzz_no_inline = MultiZarrToZarr([ref], concat_dims=["x"], inline_threshold=None)
+    mzz_no_inline = MultiZarrToZarr([ref], concat_dims=["x"], inline_threshold=0)
     # Should be okay because inline_threshold=None so we don't check the file size
     # in order to see if it should be inlined
     mzz_no_inline.translate()


### PR DESCRIPTION
I am trying to combine some massive S3-based Zarr references. A `MultiZarrToZarr` operation which would otherwise take a minute would take days because the size of each file on S3 is being queried. Thus I want to be able to pass in `inline_threshold=None` so that my datasets combine in a reasonable timeframe.