### PR TITLE
Pin eccodes <2.38 in CI

### DIFF
--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -13,6 +13,9 @@ dependencies:
   - pandas
   - cfgrib
   - cftime
+  # Temporary workaround for #508
+  - eccodes <2.38
+
   - astropy
   - requests
   - aiohttp

--- a/ci/environment-py311.yml
+++ b/ci/environment-py311.yml
@@ -12,6 +12,9 @@ dependencies:
   - h5py
   - pandas
   - cfgrib
+  # Temporary workaround for #508
+  - eccodes <2.38
+
   - cftime
   - astropy
   - requests

--- a/ci/environment-py312.yml
+++ b/ci/environment-py312.yml
@@ -12,6 +12,9 @@ dependencies:
   - h5py
   - pandas
   - cfgrib
+  # Temporary workaround for #508
+  - eccodes <2.38
+
   - cftime
   - astropy
   - requests


### PR DESCRIPTION
Temporary workaround for #508 to turn the CI green until we figure out what's going on with eccodes