### PR TITLE
Added initial code for local index definition of grib files.

### DIFF
--- a/kerchunk/grib2.py
+++ b/kerchunk/grib2.py
@@ -274,11 +274,12 @@ def scan_grib(
                     )
                     continue
 
-                if idx:
+                if idx and coord in ["time", "valid_time"]:
                     line = ""
                     if coord == "time":
                         time = dt.datetime.fromtimestamp(x, tz=pytz.UTC)
                         line = f"{count}:{offset}:d={time.strftime('%Y%m%d%H')}:{varName.upper()}"
+                        count += 1
                     elif coord == "valid_time":
                         valid_time = dt.datetime.fromtimestamp(x, tz=pytz.UTC)
                         diff = int((valid_time - time).total_seconds() / 3600)


### PR DESCRIPTION
This is thed demo for an initial version of the local grib index file defintions. The code still needs more update. Below is the output  created in a `.idx` file
```
1:0:d=2023092800:V:6 hour fcst
2:955132:d=2023092800:ABSV:6 hour fcst
3:1898414:d=2023092800:CLWMR:6 hour fcst
4:2243950:d=2023092800:ICMR:6 hour fcst
5:2519285:d=2023092800:RWMR:6 hour fcst
6:2800049:d=2023092800:SNMR:6 hour fcst
7:2922175:d=2023092800:GRLE:6 hour fcst
8:2995158:d=2023092800:O3MR:6 hour fcst
...
```
