### PR TITLE
add repro case?

### DIFF
--- a/tests/test_read_parquet.py
+++ b/tests/test_read_parquet.py
@@ -1,0 +1,25 @@
+
+def test_read_parquet_td(tmp_path):
+    import pandas as pd
+    import numpy as np
+
+
+    df = pd.DataFrame(
+        data=dict(
+            ints=np.linspace(1,25, num=25, dtype="int64"),
+            floats=np.linspace(1,25, num=25, dtype="float64"),
+            dates=pd.date_range("2024-01-01T00", "2024-01-02T00", freq="h"),
+            deltas=pd.timedelta_range(start="1 h", end="25 h", freq="h"),
+        )
+    )
+
+    fpath = tmp_path / "fixture.parquet"
+    df.to_parquet(fpath)
+
+    result = pd.read_parquet(fpath)
+
+    pd.testing.assert_frame_equal(result, df)
+
+
+
+


### PR DESCRIPTION

I tried to add this as a repro case for the issue I see in #528 where I have to use `engine='fastparquet'` to successfully read a file with timedelta64 types... but I can't repro the issue.

```
        test_path = os.path.join(
            THIS_DIR, "grib_idx_fixtures", sample_prefix, "kerchunk_index.parquet"
        )
        expected = pd.read_parquet(test_path) #, engine="fastparquet")
>       pd.testing.assert_frame_equal(k_index, expected)
E       AssertionError: Attributes of DataFrame.iloc[:, 4] (column name="step") are different
E
E       Attribute "dtype" are different
E       [left]:  timedelta64[ns]
E       [right]: object
```