### PR TITLE
change compression to compressor in netCDF.3.translate zarr.create_dataset calls

### DIFF
--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -197,7 +197,7 @@ class NetCDF3ToZarr(netcdf_file):
                     dtype=var.data.dtype,
                     fill_value=fill,
                     chunks=shape,
-                    compression=None,
+                    compressor=None,
                 )
                 part = ".".join(["0"] * len(shape)) or "0"
                 k = f"{dim}/{part}"
@@ -251,7 +251,7 @@ class NetCDF3ToZarr(netcdf_file):
                     dtype=base,
                     fill_value=fill,
                     chunks=(1,) + dtype.shape,
-                    compression=None,
+                    compressor=None,
                 )
                 arr.attrs.update(
                     {


### PR DESCRIPTION
Replaces 'compression` with correct `compressor`argument in netCDF3.translate zarr.create_dataset calls.
Fixes #534 
Tested with python 3.12 and kerchunk v.0.2.7 on RHEL8 OS
