### PR TITLE
Add more specific version requirements for Zarr in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "numcodecs",
   "numpy",
   "ujson",
-  "zarr>=3",
+  "zarr>=3.0.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "numcodecs",
   "numpy",
   "ujson",
-  "zarr>3",
+  "zarr>=3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Zarr Python 3 is needed, not >3