### PR TITLE
Remove log setup

### DIFF
--- a/kerchunk/hdf.py
+++ b/kerchunk/hdf.py
@@ -38,7 +38,6 @@ _HIDDEN_ATTRS = {  # from h5netcdf.attrs
     "_nc3_strict",
     "_NCProperties",
 }
-fsspec.utils.setup_logging(lggr)
 
 
 class SingleHdf5ToZarr:


### PR DESCRIPTION
I believe this line was accidentally left in from #516. My notebook is inundated with debug output from kerchunk because of this line to the point that it freezes jupyterlab.