### PR TITLE
Enable class version of TIFF kerchunker

### DIFF
--- a/tests/test_tiff.py
+++ b/tests/test_tiff.py
@@ -1,5 +1,4 @@
 import glob
-import fsspec
 import os.path
 import zarr
 import pytest

--- a/tests/test_tiff.py
+++ b/tests/test_tiff.py
@@ -32,6 +32,33 @@ def test_one():
     assert z["0"][:].max() == 8
 
 
+def test_one_class():
+    from collections import Counter
+
+    fn = files[0]
+    out = kerchunk.tiff.TiffToZarr(fn, inline_threshold=1000).translate()
+
+    # test inlineing
+    c = Counter(type(_) for k, _ in out.items() if ".z" not in k)
+    assert c[list] == 72
+    assert c[bytes] == 24
+
+    # test zarr output
+    store = refs_as_store(out)
+    z = zarr.open(store, zarr_format=2)
+    assert list(z) == ["0", "1", "2"]
+    assert z.attrs["multiscales"] == [
+        {
+            "datasets": [{"path": "0"}, {"path": "1"}, {"path": "2"}],
+            "metadata": {},
+            "name": "",
+            "version": "0.1",
+        }
+    ]
+    assert z["0"].shape == (2048, 2048)
+    assert z["0"][:].max() == 8
+
+
 def test_coord():
     fn = files[0]
     out = kerchunk.tiff.tiff_to_zarr(fn)


### PR DESCRIPTION
Fixes #547 

@maxrjones , note: tifffile works just fine with zarr 3. This might be new.