### PR TITLE
beyond.rst: mention GDAL implementation

### DIFF
--- a/docs/source/beyond.rst
+++ b/docs/source/beyond.rst
@@ -23,3 +23,6 @@ at https://observablehq.com/@manzt/ome-tiff-as-filesystemreference.
 
     <script data-goatcounter="https://kerchunk.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>
+
+GDAL (since 3.11) has also support for JSON and Parquet reference stores as
+described in https://gdal.org/en/stable/drivers/raster/zarr.html


### PR DESCRIPTION
Cf https://github.com/OSGeo/gdal/pull/12099

Probably to be merged once GDAL 3.11 is released (beginning of May 2025)