### PR TITLE
Ignore errors when decoding attributes in netCDF3.py

### DIFF
--- a/kerchunk/netCDF3.py
+++ b/kerchunk/netCDF3.py
@@ -216,7 +216,7 @@ class NetCDF3ToZarr(netcdf_file):
                 ]
             arr.attrs.update(
                 {
-                    k: v.decode() if isinstance(v, bytes) else str(v)
+                    k: v.decode(erros="ignore") if isinstance(v, bytes) else str(v)
                     for k, v in var._attributes.items()
                     if k not in ["_FillValue", "missing_value"]
                 }


### PR DESCRIPTION
Faced some issues when using virtualizarr because of this