### PR TITLE
Fix test environemt by removing zarr from pip install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/ci/environment-py311.yml
+++ b/ci/environment-py311.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.11
   - dask
-  - zarr
+  - zarr>=3.0.1
   - xarray>=2024.10.0
   - h5netcdf
   - h5py

--- a/ci/environment-py311.yml
+++ b/ci/environment-py311.yml
@@ -36,4 +36,3 @@ dependencies:
   - netCDF4
   - pip:
       - git+https://github.com/fsspec/filesystem_spec
-      - git+https://github.com/zarr-developers/zarr-python

--- a/ci/environment-py312.yml
+++ b/ci/environment-py312.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.12
   - dask
-  - zarr
+  - zarr>=3.0.1
   - xarray>=2024.10.0
   - h5netcdf
   - h5py

--- a/ci/environment-py312.yml
+++ b/ci/environment-py312.yml
@@ -36,4 +36,3 @@ dependencies:
   - netCDF4
   - pip:
       - git+https://github.com/fsspec/filesystem_spec
-      - git+https://github.com/zarr-developers/zarr-python


### PR DESCRIPTION
As faced in during https://github.com/fsspec/kerchunk/pull/565 the tests were failing likely because installing zarr via pip `git+https://github.com/zarr-developers/zarr-python` would provide a unstable version of `zarr` (3.0.9+devXXX). 

I get that would be nice to always test using the zarr `main` branch to catch issues yearly on but I fear this makes it harder to probe for real issues with kerchunk.

So this PR:
- Leaves only the option of using a relased version of zarr installed via `condaforge`.
- It also locks it to `>=3.0.1` as seen in [`pyproject.toml`](https://github.com/fsspec/kerchunk/blob/main/pyproject.toml#L27)
- Enables the option to manually trigger the tests again if there's need be (as currently `zarr-python` main branch is `3.1.0`)

If you do want to run the tests against the latest python, I think cherry-picking  b5038f685796022350bd528c8bb35a71c4e1748 would allow everyone to rerun the tests manually (I think you can already do it @martindurant).