### PR TITLE
No endinaness on one-byte type

### DIFF
--- a/tests/test_combine_dask.py
+++ b/tests/test_combine_dask.py
@@ -17,7 +17,7 @@ def test_simplest(m, n_batches):
         m.pipe(
             {
                 f"data{i}/.zgroup": b'{"zarr_format":2}',
-                f"data{i}/data/.zarray": b'{"chunks":[3],"compressor": null,"dtype": "<i1",'
+                f"data{i}/data/.zarray": b'{"chunks":[3],"compressor": null,"dtype": "|i1",'
                 b'"fill_value": 0,"filters": null,"order": "C",'
                 b'"shape": [3],"zarr_format": 2}',
                 f"data{i}/data/0": f"{i}{i}{i}".encode(),


### PR DESCRIPTION
Fixed a few of the test errors from recent zarr releases.