### PR TITLE
Squeeze fill value.

### DIFF
--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -217,6 +217,8 @@ def encode_fill_value(v: Any, dtype: np.dtype, compressor: Any = None) -> Any:
     # early out
     if v is None:
         return v
+    v = np.asanyarray(v, dtype=dtype)
+    v = v.squeeze()
     if dtype.kind == "V" and dtype.hasobject:
         if compressor is None:
             raise ValueError("missing compressor for object array")

--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -217,14 +217,14 @@ def encode_fill_value(v: Any, dtype: np.dtype, compressor: Any = None) -> Any:
     # early out
     if v is None:
         return v
-    
+
     # Assure that v is a numpy array of the appropriate dtype
     v = np.asanyarray(v, dtype=dtype)
     # If v is 1D and only has 1 element, squeeze it to 0-D ndarray.
     # When v is not 0-D, calling int/float/bool on v will fail
     # We still need an ndarray in case dtype is a date
     v = v.squeeze()
-    
+
     if dtype.kind == "V" and dtype.hasobject:
         if compressor is None:
             raise ValueError("missing compressor for object array")

--- a/kerchunk/utils.py
+++ b/kerchunk/utils.py
@@ -217,8 +217,14 @@ def encode_fill_value(v: Any, dtype: np.dtype, compressor: Any = None) -> Any:
     # early out
     if v is None:
         return v
+    
+    # Assure that v is a numpy array of the appropriate dtype
     v = np.asanyarray(v, dtype=dtype)
+    # If v is 1D and only has 1 element, squeeze it to 0-D ndarray.
+    # When v is not 0-D, calling int/float/bool on v will fail
+    # We still need an ndarray in case dtype is a date
     v = v.squeeze()
+    
     if dtype.kind == "V" and dtype.hasobject:
         if compressor is None:
             raise ValueError("missing compressor for object array")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,3 +176,10 @@ def test_deflate_zip_archive(m):
 
     fs = fsspec.filesystem("reference", fo=refs2)
     assert dec.decode(fs.cat("b")) == data
+
+
+def test_encode_fill_value():
+    assert kerchunk.utils.encode_fill_value(np.array([9999]), np.dtype('int')) == 9999
+    assert kerchunk.utils.encode_fill_value(np.array(9999), np.dtype('int')) == 9999
+    assert kerchunk.utils.encode_fill_value([9999], np.dtype('int')) == 9999
+    assert kerchunk.utils.encode_fill_value(9999, np.dtype('int')) == 9999

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -179,7 +179,7 @@ def test_deflate_zip_archive(m):
 
 
 def test_encode_fill_value():
-    assert kerchunk.utils.encode_fill_value(np.array([9999]), np.dtype('int')) == 9999
-    assert kerchunk.utils.encode_fill_value(np.array(9999), np.dtype('int')) == 9999
-    assert kerchunk.utils.encode_fill_value([9999], np.dtype('int')) == 9999
-    assert kerchunk.utils.encode_fill_value(9999, np.dtype('int')) == 9999
+    assert kerchunk.utils.encode_fill_value(np.array([9999]), np.dtype("int")) == 9999
+    assert kerchunk.utils.encode_fill_value(np.array(9999), np.dtype("int")) == 9999
+    assert kerchunk.utils.encode_fill_value([9999], np.dtype("int")) == 9999
+    assert kerchunk.utils.encode_fill_value(9999, np.dtype("int")) == 9999


### PR DESCRIPTION
Resolves a TypeError where int/float/str/bool care called on `v` and `v` is a 1D array of 1 element.

Addresses #582 